### PR TITLE
improve spec helper errors

### DIFF
--- a/src/spec_helpers/select_combo_box_option.js
+++ b/src/spec_helpers/select_combo_box_option.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { waitFor, findByRole, getByRole } from '@testing-library/react';
+import { waitFor, findByRole, getByRole, queryAllByRole, isInaccessible, prettyDOM, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { computeAccessibleDescription } from 'dom-accessibility-api';
 
 function options(name) {
   if (typeof name === 'string' || name instanceof RegExp) {
@@ -48,15 +49,51 @@ export async function selectComboBoxOption({ from, searchFor, select, container 
     userEvent.type(comboBox, searchFor);
   }
 
+  // If the box contains previous or default options then allow the update to complete
+  await act(async () => {});
+
   // Wait for the list box and option to appear
   let listBox;
   let option;
-  await waitFor(() => {
-    const ids = (comboBox.getAttribute('aria-controls') || '').split(/\s+/).filter(Boolean);
-    listBox = document.querySelector(ids.map((id) => `[role="listbox"]#${id}`).join(','));
-    expect(listBox).toBeInstanceOf(HTMLElement);
-    option = getByRole(listBox, 'option', options(select));
-  });
+  try {
+    await waitFor(() => {
+      const ids = (comboBox.getAttribute('aria-controls') || '').split(/\s+/).filter(Boolean);
+      listBox = document.querySelector(ids.map((id) => `[role="listbox"]#${id}`).join(','));
+      expect(listBox).toBeInstanceOf(HTMLElement);
+      expect(listBox).toBeVisible();
+      option = getByRole(listBox, 'option', options(select));
+    });
+  } catch (e) {
+    // Display pretty errors that will help the developer
+    if (!e.name === 'TestingLibraryElementError') {
+      throw e;
+    }
+    if (!listBox || isInaccessible(listBox)) {
+      let message = 'Unable to find visible listbox for combobox';
+      message += `\n\n${prettyDOM(comboBox)}`;
+      message += `\n\nwith description:\n\n"${computeAccessibleDescription(comboBox).trim()}"`;
+      message += '\n\n--------------------------------------------------';
+
+      const listBoxes = queryAllByRole(document.body, 'listbox', { hidden: true });
+      if (!listBox) {
+        message += `\n\nNo elements with the role "listbox" found in document:\n\n${prettyDOM(document.body)}`;
+      } else {
+        message += '\n\nHere are the found elements with the role "listbox":';
+        listBoxes.forEach((box) => {
+          message += `\n\n${prettyDOM(box)}`;
+        });
+      }
+      throw new Error(message);
+    }
+    try {
+      option = getByRole(listBox, 'option', options(select));
+    } catch (error) {
+      error.message += '\n\n--------------------------------------------------';
+      error.message += `\n\nFor combobox:\n\n${prettyDOM(comboBox)}`;
+      error.message += `\n\nwith description:\n\n"${computeAccessibleDescription(comboBox).trim()}"`;
+      throw error;
+    }
+  }
 
   // Select the option
   userEvent.click(option);


### PR DESCRIPTION
If the select_combo_box_option fails to find an option, show much nicer messages so it is more obvious why.