### PR TITLE
hide highlighted text from screen-readers

### DIFF
--- a/src/components/highlight_value.jsx
+++ b/src/components/highlight_value.jsx
@@ -3,12 +3,30 @@ import PropTypes from 'prop-types';
 import { Highlight } from './highlight';
 import { Context } from '../context';
 
+function emptyHighlight(highlight) {
+  return !highlight.length || (highlight.length === 1 && typeof highlight[0] === 'string');
+}
+
 export function HighlightValue({ children: value, highlight, inverse, search: _search, ...props }) {
-  const { search, props: { value: _value } } = useContext(Context);
+  const { search, props: { value: _value, visuallyHiddenClassName } } = useContext(Context);
+  const highlighted = highlight(value ?? '', _search ?? (search || _value?.label), props);
+
+  if (emptyHighlight(highlighted)) {
+    return highlighted.join('');
+  }
+
+  // Accessible naming treats inline elements as block and adds additional white space
   return (
-    <Highlight inverse={inverse}>
-      {highlight(value ?? '', _search ?? (search || _value?.label), props)}
-    </Highlight>
+    <>
+      <span className={visuallyHiddenClassName}>
+        {value}
+      </span>
+      <span aria-hidden="true">
+        <Highlight inverse={inverse}>
+          {highlighted}
+        </Highlight>
+      </span>
+    </>
   );
 }
 

--- a/src/components/highlighters/__snapshots__/pre_highlight.test.jsx.snap
+++ b/src/components/highlighters/__snapshots__/pre_highlight.test.jsx.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`converts <em> in html strings to a highlight 1`] = `
+<div>
+  <span
+    class="sr-only"
+  >
+    foo &lt;em&gt;bar&lt;/em&gt; &lt;em&gt;foe&lt;/em&gt;
+  </span>
+  <span
+    aria-hidden="true"
+  >
+    foo 
+    <mark>
+      bar
+    </mark>
+     
+    <mark>
+      foe
+    </mark>
+  </span>
+</div>
+`;
+
+exports[`inverses the highlight 1`] = `
+<div>
+  <span
+    class="sr-only"
+  >
+    foo &lt;em&gt;bar&lt;/em&gt; &lt;em&gt;foe&lt;/em&gt;
+  </span>
+  <span
+    aria-hidden="true"
+  >
+    <mark>
+      foo 
+    </mark>
+    bar
+    <mark>
+       
+    </mark>
+    foe
+  </span>
+</div>
+`;

--- a/src/components/highlighters/__snapshots__/prefix_highlight.test.jsx.snap
+++ b/src/components/highlighters/__snapshots__/prefix_highlight.test.jsx.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`highlights existing value 1`] = `
+<div>
+  <span
+    class="sr-only"
+  >
+    bar foo bar
+  </span>
+  <span
+    aria-hidden="true"
+  >
+    <mark>
+      bar
+    </mark>
+     foo bar
+  </span>
+</div>
+`;
+
+exports[`highlights the first prefix 1`] = `
+<div>
+  <span
+    class="sr-only"
+  >
+    bar foo bar
+  </span>
+  <span
+    aria-hidden="true"
+  >
+    <mark>
+      bar
+    </mark>
+     foo bar
+  </span>
+</div>
+`;
+
+exports[`inverses the highlight 1`] = `
+<div>
+  <span
+    class="sr-only"
+  >
+    bar foo bar
+  </span>
+  <span
+    aria-hidden="true"
+  >
+    bar
+    <mark>
+       foo bar
+    </mark>
+  </span>
+</div>
+`;

--- a/src/components/highlighters/__snapshots__/substring_highlight.test.jsx.snap
+++ b/src/components/highlighters/__snapshots__/substring_highlight.test.jsx.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`highlights a substring 1`] = `
+<div>
+  <span
+    class="sr-only"
+  >
+    foo bar foo bar
+  </span>
+  <span
+    aria-hidden="true"
+  >
+    foo 
+    <mark>
+      bar
+    </mark>
+     foo bar
+  </span>
+</div>
+`;
+
+exports[`highlights an existing value substring 1`] = `
+<div>
+  <span
+    class="sr-only"
+  >
+    foo bar foo bar
+  </span>
+  <span
+    aria-hidden="true"
+  >
+    foo 
+    <mark>
+      bar
+    </mark>
+     foo bar
+  </span>
+</div>
+`;
+
+exports[`inverses the highlight 1`] = `
+<div>
+  <span
+    class="sr-only"
+  >
+    foo bar foo bar
+  </span>
+  <span
+    aria-hidden="true"
+  >
+    <mark>
+      foo 
+    </mark>
+    bar
+    <mark>
+       foo bar
+    </mark>
+  </span>
+</div>
+`;

--- a/src/components/highlighters/__snapshots__/token_highlight.test.jsx.snap
+++ b/src/components/highlighters/__snapshots__/token_highlight.test.jsx.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`highlights all tokens 1`] = `
+<div>
+  <span
+    class="sr-only"
+  >
+    foo bar foo bar
+  </span>
+  <span
+    aria-hidden="true"
+  >
+    foo 
+    <mark>
+      bar
+    </mark>
+     foo 
+    <mark>
+      bar
+    </mark>
+  </span>
+</div>
+`;
+
+exports[`highlights existing value 1`] = `
+<div>
+  <span
+    class="sr-only"
+  >
+    foo bar foo bar
+  </span>
+  <span
+    aria-hidden="true"
+  >
+    foo 
+    <mark>
+      bar
+    </mark>
+     foo 
+    <mark>
+      bar
+    </mark>
+  </span>
+</div>
+`;
+
+exports[`highlights the start of tokens 1`] = `
+<div>
+  <span
+    class="sr-only"
+  >
+    "barfoo"
+  </span>
+  <span
+    aria-hidden="true"
+  >
+    "
+    <mark>
+      bar
+    </mark>
+    foo"
+  </span>
+</div>
+`;
+
+exports[`inverses the highlight 1`] = `
+<div>
+  <span
+    class="sr-only"
+  >
+    foo bar foo bar
+  </span>
+  <span
+    aria-hidden="true"
+  >
+    <mark>
+      foo 
+    </mark>
+    bar
+    <mark>
+       foo 
+    </mark>
+    bar
+  </span>
+</div>
+`;

--- a/src/components/highlighters/pre_highlight.test.jsx
+++ b/src/components/highlighters/pre_highlight.test.jsx
@@ -5,7 +5,7 @@ import { Context } from '../../context';
 
 function TestHighlight({ children, inverse, ...props }) {
   return (
-    <Context.Provider value={{ ...props, props: { value: null } }}>
+    <Context.Provider value={{ ...props, props: { value: null, visuallyHiddenClassName: 'sr-only' } }}>
       <PreHighlight start="<em>" end="</em>" inverse={inverse}>
         {children}
       </PreHighlight>
@@ -38,7 +38,7 @@ it('converts <em> in html strings to a highlight', () => {
     </TestHighlight>
   ));
 
-  expect(container).toContainHTML('<div>foo <mark>bar</mark> <mark>foe</mark></div>');
+  expect(container).toMatchSnapshot();
 });
 
 it('inverses the highlight', () => {
@@ -48,5 +48,5 @@ it('inverses the highlight', () => {
     </TestHighlight>
   ));
 
-  expect(container).toContainHTML('<div><mark>foo </mark>bar<mark> </mark>foe</div>');
+  expect(container).toMatchSnapshot();
 });

--- a/src/components/highlighters/prefix_highlight.test.jsx
+++ b/src/components/highlighters/prefix_highlight.test.jsx
@@ -5,7 +5,7 @@ import { Context } from '../../context';
 
 function TestHighlight({ children, inverse, value, ...props }) {
   return (
-    <Context.Provider value={{ ...props, props: { value } }}>
+    <Context.Provider value={{ ...props, props: { value, visuallyHiddenClassName: 'sr-only' } }}>
       <PrefixHighlight inverse={inverse}>
         {children}
       </PrefixHighlight>
@@ -48,7 +48,7 @@ it('highlights the first prefix', () => {
     </TestHighlight>
   ));
 
-  expect(container).toContainHTML('<div><mark>bar</mark> foo bar</div>');
+  expect(container).toMatchSnapshot();
 });
 
 it('highlights existing value', () => {
@@ -58,7 +58,7 @@ it('highlights existing value', () => {
     </TestHighlight>
   ));
 
-  expect(container).toContainHTML('<div><mark>bar</mark> foo bar</div>');
+  expect(container).toMatchSnapshot();
 });
 
 it('inverses the highlight', () => {
@@ -68,5 +68,5 @@ it('inverses the highlight', () => {
     </TestHighlight>
   ));
 
-  expect(container).toContainHTML('<div>bar<mark> foo bar</mark></div>');
+  expect(container).toMatchSnapshot();
 });

--- a/src/components/highlighters/substring_highlight.test.jsx
+++ b/src/components/highlighters/substring_highlight.test.jsx
@@ -5,7 +5,7 @@ import { Context } from '../../context';
 
 function TestHighlight({ children, value, inverse, ...props }) {
   return (
-    <Context.Provider value={{ ...props, props: { value } }}>
+    <Context.Provider value={{ ...props, props: { value, visuallyHiddenClassName: 'sr-only' } }}>
       <SubstringHighlight inverse={inverse}>
         {children}
       </SubstringHighlight>
@@ -48,7 +48,7 @@ it('highlights a substring', () => {
     </TestHighlight>
   ));
 
-  expect(container).toContainHTML('<div>foo <mark>bar</mark> foo bar</div>');
+  expect(container).toMatchSnapshot();
 });
 
 it('highlights an existing value substring', () => {
@@ -58,7 +58,7 @@ it('highlights an existing value substring', () => {
     </TestHighlight>
   ));
 
-  expect(container).toContainHTML('<div>foo <mark>bar</mark> foo bar</div>');
+  expect(container).toMatchSnapshot();
 });
 
 it('inverses the highlight', () => {
@@ -68,5 +68,5 @@ it('inverses the highlight', () => {
     </TestHighlight>
   ));
 
-  expect(container).toContainHTML('<div><mark>foo </mark>bar<mark> foo bar</mark></div>');
+  expect(container).toMatchSnapshot();
 });

--- a/src/components/highlighters/token_highlight.test.jsx
+++ b/src/components/highlighters/token_highlight.test.jsx
@@ -5,7 +5,7 @@ import { Context } from '../../context';
 
 function TestHighlight({ children, value, inverse, ...props }) {
   return (
-    <Context.Provider value={{ ...props, props: { value } }}>
+    <Context.Provider value={{ ...props, props: { value, visuallyHiddenClassName: 'sr-only' } }}>
       <TokenHighlight inverse={inverse}>
         {children}
       </TokenHighlight>
@@ -48,7 +48,7 @@ it('highlights all tokens', () => {
     </TestHighlight>
   ));
 
-  expect(container).toContainHTML('<div>foo <mark>bar</mark> foo <mark>bar</mark></div>');
+  expect(container).toMatchSnapshot();
 });
 
 it('highlights the start of tokens', () => {
@@ -58,7 +58,7 @@ it('highlights the start of tokens', () => {
     </TestHighlight>
   ));
 
-  expect(container).toContainHTML('<div>"<mark>bar</mark>foo"');
+  expect(container).toMatchSnapshot();
 });
 
 it('highlights existing value', () => {
@@ -68,7 +68,7 @@ it('highlights existing value', () => {
     </TestHighlight>
   ));
 
-  expect(container).toContainHTML('<div>foo <mark>bar</mark> foo <mark>bar</mark></div>');
+  expect(container).toMatchSnapshot();
 });
 
 it('inverses the highlight', () => {
@@ -78,5 +78,5 @@ it('inverses the highlight', () => {
     </TestHighlight>
   ));
 
-  expect(container).toContainHTML('<div><mark>foo </mark>bar<mark> foo </mark>bar</div>');
+  expect(container).toMatchSnapshot();
 });


### PR DESCRIPTION
Some screen-readers, and react-testing-library read out `<mark>he</mark>llo` as "he llo" rather than "hello".

This maybe fixed one-day, but for now hide the highlighting from screen-readers and give and sr-only unhighlighted text