### PR TITLE
fix pre highlighter screen-reader output contains pre tags

### DIFF
--- a/src/components/highlight_value.jsx
+++ b/src/components/highlight_value.jsx
@@ -19,7 +19,7 @@ export function HighlightValue({ children: value, highlight, inverse, search: _s
   return (
     <>
       <span className={visuallyHiddenClassName}>
-        {value}
+        {highlighted.join('')}
       </span>
       <span aria-hidden="true">
         <Highlight inverse={inverse}>


### PR DESCRIPTION
Fixes the output of the prehighlighter for screen-readers