### PR TITLE
fix cjs includes const/let

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": [
     "@babel/preset-react",
-    "@babel/preset-env"
+    ["@babel/preset-env", { "targets": { "ie": "11" } }]
   ],
   "plugins": [
     ["@babel/plugin-transform-runtime", { "regenerator": true }]


### PR DESCRIPTION
cjs build was intended to be compatible with IE11 without transpiling and should not include `let` and `const`