### PR TITLE
scroll into view without managed focus

### DIFF
--- a/src/components/combo_box.jsx
+++ b/src/components/combo_box.jsx
@@ -146,8 +146,12 @@ export const ComboBox = forwardRef(({ placeholder, ...rawProps }, ref) => {
   ), [expanded, options, selectedOption, search, value]);
 
   useLayoutEffect(() => {
-    if (focusedOption && managedFocus && focusListBox && showListBox) {
-      focusedRef.current?.focus?.();
+    if (focusedOption && focusListBox && showListBox) {
+      if (managedFocus) {
+        focusedRef.current?.focus();
+      } else {
+        focusedRef.current?.scrollIntoView?.({ block: 'nearest' });
+      }
     } else if (expanded && document.activeElement !== inputRef.current) {
       inputRef.current.focus();
     }

--- a/src/components/combo_box.test.jsx
+++ b/src/components/combo_box.test.jsx
@@ -1667,6 +1667,18 @@ describe('managedFocus', () => {
       expect(getAllByRole('option')[1]).toHaveAttribute('aria-selected', 'true');
     });
 
+    it('scrolls the element into view', () => {
+      Element.prototype.scrollIntoView = jest.fn();
+      const { getByRole } = render(
+        <ComboBoxWrapper options={options} managedFocus={false} />,
+      );
+      const comboBox = getByRole('combobox');
+      comboBox.focus();
+      fireEvent.keyDown(comboBox, { key: 'ArrowDown' });
+      fireEvent.keyDown(comboBox, { key: 'ArrowDown' });
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' });
+    });
+
     it('allows an option to be selected', () => {
       const { getByRole } = render(
         <ComboBoxWrapper options={options} managedFocus={false} />,

--- a/src/components/drop_down.jsx
+++ b/src/components/drop_down.jsx
@@ -80,9 +80,12 @@ export const DropDown = forwardRef((rawProps, ref) => {
 
   useLayoutEffect(() => {
     if (expanded && focusedOption && managedFocus) {
-      focusedRef.current?.focus?.();
+      focusedRef.current?.focus();
     } else if (expanded) {
-      comboBoxRef.current.focus();
+      if (document.activeElement !== comboBoxRef.current) {
+        comboBoxRef.current.focus();
+      }
+      focusedRef.current?.scrollIntoView?.({ block: 'nearest' });
     }
   }, [expanded, managedFocus, focusedOption]);
 

--- a/src/components/drop_down.test.jsx
+++ b/src/components/drop_down.test.jsx
@@ -1401,6 +1401,19 @@ describe('managedFocus', () => {
       expect(comboBox).toHaveAttribute('aria-activedescendant', getAllByRole('option')[1].id);
     });
 
+    it('scrolls the element into view', () => {
+      Element.prototype.scrollIntoView = jest.fn();
+      const { getByRole } = render(
+        <DropDownWrapper options={options} managedFocus={false} />,
+      );
+      const comboBox = getByRole('combobox');
+      fireEvent.click(comboBox);
+      const listBox = getByRole('listbox');
+      expect(comboBox).toHaveFocus();
+      fireEvent.keyDown(listBox, { key: 'ArrowDown' });
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' });
+    });
+
     it('allows an option to be selected', () => {
       const { getByRole } = render(
         <DropDownWrapper options={options} managedFocus={false} />,


### PR DESCRIPTION
Adds scrolling options into view if `managedFocus` is false.