### PR TITLE
turn off managed focus on non-safari mac

### DIFF
--- a/docs/combo_box.md
+++ b/docs/combo_box.md
@@ -61,6 +61,7 @@ The `onSearch` function is called with the current search value and should be us
 | `onSearch`          | `Function`              | Handler for searching.  See [Searchers][2]                          |
 | `onLayoutListBox`   | `Function`              | Handler for custom listbox positioning. See [onLayoutListBox][3]    |
 | `onValue`           | `Function`              | Handler for when a value is selected                                |
+| `managedFocus`      | `Boolean`               | Use managed focus                                                   |
 | `autoselect`        | `Boolean` or `"inline"` | If set the first matching option will be automatically selected     |
 | `expandOnFocus`     | `Boolean`               | Show available options when focusing.  Defaults to true             |
 | `findSuggestion`    | `Function`              | Customise finding the autoselect option                             |
@@ -111,8 +112,9 @@ the html element, or a full component if you want a more far reaching change.  B
     </ListBoxListComponent>
     <OpenButtonComponent {...openButtonProps} />                      // <span>
     <ClearButtonComponent {...clearButtonProps} />                    // <span>
-    <FoundDescriptionComponent className={visuallyHiddenClassName} /> // Tells screen readers how many results were found
+    <FoundDescriptionComponent className={visuallyHiddenClassName} /> // Description with the number of found items 
     <NotFoundComponent {...notFoundProps} />                          // <div>
+    <ScreenReaderMessage />                                           // ARIA live region with the number of found items
   </ListBoxComponent>
 </WrapperComponent>
 ```
@@ -158,11 +160,9 @@ Return `true` to select an option, `null` to continue finding an option, or `fal
 
 ### `managedFocus` (`Boolean`)
 
-By default this is `true`.  It means the browser focus follows the current selected option.
+By default this is `true`, expect on non-Safari browser on a Mac.  It means the browser focus follows the current selected option.
 
-If `false` the combo box element remains focused and the current selected option is
-marked with `aria-activedescendant`.  This method is found to have incomplete compatibility
-with many screen-readers.
+If `false` the combo box element remains focused and the current selected option is marked with `aria-activedescendant`.
 
 ### `onLayoutListBox` (`Function`)
 

--- a/docs/drop_down.md
+++ b/docs/drop_down.md
@@ -58,6 +58,7 @@ If you wish to submit the value add a `<input type="hidden" name="name" value="v
 | `onLayoutListBox` | `Function` | Handler for custom listbox positioning. See [onLayoutListBox][2] |
 | `skipOption`      | `Function` | Allows options to be skipped with keyboard navigation            |
 | `findOption`      | `Function` | Customise finding an option when typing                          |
+| `managedFocus`    | `Function` | Use managed focus                                                |
 
 Additional props can be used to customise the component.  See customisation.
 
@@ -109,7 +110,7 @@ By default this is `true`.  It means the browser focus follows the current selec
 
 If `false` the combo box element remains focused and the current selected option is
 marked with `aria-activedescendant`.  This method is found to have incomplete compatibility
-with many screen-readers.
+with some screen-readers.
 
 #### `skipOption` (`Function`)
 

--- a/examples/combo_box/without_managed_focus/README.md
+++ b/examples/combo_box/without_managed_focus/README.md
@@ -4,4 +4,6 @@ A combo box without managed focus.
 
 The focus remains in the input, and the currently selected item is set by `aria-activedescendant`.
 
-This is technically correct and makes editing the input value easier. However, it is found to be unreliable in many screen-readers and requires additional code to keep the selected option on the screen.
+The default is to use `managedFocus` as this has the best backwards compatibility.  However, note that Chrome on
+a Mac defaults to `managedFocus=false` due to a bug in its integration with VoiceOver.
+

--- a/examples/drop_down/without_managed_focus/README.md
+++ b/examples/drop_down/without_managed_focus/README.md
@@ -4,5 +4,4 @@
 and does not follow the selected option.  Instead `aria-activedescendant` sets
 the focused option.
 
-While this is technically correct, it does not work well in all screen-readers.
-
+The default is to use `managedFocus` as this has the best browser and screen-reader compatibility.

--- a/src/components/combo_box.jsx
+++ b/src/components/combo_box.jsx
@@ -21,6 +21,8 @@ import { ListBox } from './list_box';
 import { ScreenReaderMessage } from './screen_reader_message';
 import { classPrefix } from '../constants/class_prefix';
 import { visuallyHiddenClassName } from '../constants/visually_hidden_class_name';
+import { isSafari } from '../sniffers/is_safari';
+import { isMac } from '../sniffers/is_mac';
 
 const allowAttributes = [
   'autoComplete', 'autoCapitalize', 'autoCorrect', 'autoFocus', 'disabled', 'inputMode',
@@ -378,7 +380,7 @@ ComboBox.defaultProps = {
   autoselect: false,
   expandOnFocus: true,
   findSuggestion: findOption,
-  managedFocus: true,
+  managedFocus: !(isMac() && !isSafari()),
   skipOption: undefined,
   showSelectedLabel: undefined,
   tabAutocomplete: false,

--- a/src/components/combo_box.mac-chrome.test.jsx
+++ b/src/components/combo_box.mac-chrome.test.jsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { render, fireEvent } from '@testing-library/react';
+
+Object.defineProperties(global.navigator, {
+  platform: {
+    get() {
+      return 'MacIntel';
+    },
+  },
+  vendor: {
+    get() {
+      return 'Goole Inc.';
+    },
+  },
+});
+
+const { ComboBox } = require('./combo_box');
+
+function ComboBoxWrapper(props) {
+  const [value, onValue] = useState(null);
+  return (
+    <ComboBox
+      id="id"
+      aria-labelledby="id-label"
+      value={value}
+      onValue={onValue}
+      {...props}
+    />
+  );
+}
+
+it('uses managedFocus = false on a mac not in safari', () => {
+  const { getByRole, getAllByRole } = render(
+    <ComboBoxWrapper options={['foo', 'bar']} />,
+  );
+  const comboBox = getByRole('combobox');
+  comboBox.focus();
+  fireEvent.keyDown(comboBox, { key: 'ArrowDown' });
+  fireEvent.keyDown(comboBox, { key: 'ArrowDown' });
+  expect(comboBox).toHaveFocus();
+  expect(comboBox).toHaveAttribute('aria-activedescendant', getAllByRole('option')[1].id);
+  expect(getAllByRole('option')[1]).toHaveAttribute('aria-selected', 'true');
+});

--- a/src/components/combo_box.mac.test.jsx
+++ b/src/components/combo_box.mac.test.jsx
@@ -1,0 +1,192 @@
+import React, { useState } from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+Object.defineProperties(global.navigator, {
+  platform: {
+    get() {
+      return 'MacIntel';
+    },
+  },
+});
+
+const { ComboBox } = require('./combo_box');
+
+function ComboBoxWrapper(props) {
+  const [value, onValue] = useState(null);
+  return (
+    <ComboBox
+      id="id"
+      aria-labelledby="id-label"
+      value={value}
+      onValue={onValue}
+      {...props}
+    />
+  );
+}
+
+function expectToBeOpen(combobox) {
+  expect(combobox).toHaveFocus();
+  const listbox = document.getElementById(combobox.getAttribute('aria-controls'));
+  expect(listbox).toBeVisible();
+  expect(combobox).not.toHaveAttribute('aria-activedescendant');
+  expect(listbox).not.toHaveAttribute('aria-activedescendant');
+}
+
+function expectToHaveFocusedOption(combobox, option) {
+  const listbox = document.getElementById(combobox.getAttribute('aria-controls'));
+  expect(listbox).toBeVisible();
+  expect(combobox).toHaveAttribute('aria-activedescendant', option.id);
+  expect(option).toHaveFocus();
+}
+
+const options = ['Apple', 'Banana', 'Orange'];
+
+describe('with an open list box', () => {
+  it('moves to the first option with the home key', () => {
+    const { getByRole, getAllByRole } = render((
+      <ComboBoxWrapper options={options} />
+    ));
+    getByRole('combobox').focus();
+    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+    fireEvent.keyDown(document.activeElement, { key: 'Home' });
+    expectToHaveFocusedOption(getByRole('combobox'), getAllByRole('option')[0]);
+  });
+
+  it('moves to the last option with the end key', () => {
+    const { getByRole, getAllByRole } = render((
+      <ComboBoxWrapper options={options} />
+    ));
+    getByRole('combobox').focus();
+    fireEvent.keyDown(document.activeElement, { key: 'End' });
+    expectToHaveFocusedOption(getByRole('combobox'), getAllByRole('option')[2]);
+  });
+
+  describe('with a selected option', () => {
+    describe('pressing Ctrl+d', () => {
+      it('moves focus back to the list box removing the selected option', () => {
+        const { getByRole } = render((
+          <ComboBoxWrapper options={options} />
+        ));
+        getByRole('combobox').focus();
+        fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+        fireEvent.keyDown(document.activeElement, { key: 'd', ctrlKey: true });
+        expectToBeOpen(getByRole('combobox'));
+      });
+    });
+
+    describe('pressing Ctrl+k', () => {
+      it('moves focus back to the list box removing the selected option', () => {
+        const { getByRole } = render((
+          <ComboBoxWrapper options={options} />
+        ));
+        getByRole('combobox').focus();
+        fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+        fireEvent.keyDown(document.activeElement, { key: 'k', ctrlKey: true });
+        expectToBeOpen(getByRole('combobox'));
+      });
+    });
+  });
+
+  describe('with a custom skipOption', () => {
+    it('allows options to be skipped pressing home', () => {
+      function skipOption(option) {
+        return option.label === 'Apple';
+      }
+      const { getByRole, getAllByRole } = render(
+        <ComboBoxWrapper options={options} skipOption={skipOption} />,
+      );
+      getByRole('combobox').focus();
+      fireEvent.keyDown(document.activeElement, { key: 'Home' });
+      expectToHaveFocusedOption(getByRole('combobox'), getAllByRole('option')[1]);
+    });
+
+    it('allows options to be skipped pressing end', () => {
+      function skipOption(option) {
+        return option.label === 'Orange';
+      }
+      const { getByRole, getAllByRole } = render(
+        <ComboBoxWrapper options={options} skipOption={skipOption} />,
+      );
+      getByRole('combobox').focus();
+      fireEvent.keyDown(document.activeElement, { key: 'End' });
+      expectToHaveFocusedOption(getByRole('combobox'), getAllByRole('option')[1]);
+    });
+  });
+});
+
+describe('with a closed list box', () => {
+  describe('pressing the Home key', () => {
+    it('does not change the option', () => {
+      const { getByRole, getAllByRole } = render((
+        <ComboBoxWrapper options={options} />
+      ));
+      getByRole('combobox').focus();
+      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      fireEvent.keyDown(document.activeElement, { key: 'Home' });
+      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      expectToHaveFocusedOption(getByRole('combobox'), getAllByRole('option')[1]);
+    });
+  });
+
+  describe('pressing the End key', () => {
+    it('does not change the option', () => {
+      const { getByRole, getAllByRole } = render((
+        <ComboBoxWrapper options={options} />
+      ));
+      getByRole('combobox').focus();
+      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      fireEvent.keyDown(document.activeElement, { key: 'End' });
+      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      expectToHaveFocusedOption(getByRole('combobox'), getAllByRole('option')[1]);
+    });
+  });
+});
+
+describe('autoselect is true', () => {
+  describe('backspace', () => {
+    describe('ctrl+d', () => {
+      it('does not auto-select an option', async () => {
+        const { getByRole } = render(
+          <ComboBoxWrapper options={['foo', 'bar']} autoselect />,
+        );
+        getByRole('combobox').focus();
+        await userEvent.type(document.activeElement, 'fo');
+        fireEvent.keyDown(getByRole('combobox'), { key: 'd', ctrlKey: true });
+        expectToBeOpen(getByRole('combobox'));
+      });
+    });
+
+    describe('delete', () => {
+      describe('ctrl+h', () => {
+        it('does not auto-select an option', async () => {
+          const { getByRole } = render(
+            <ComboBoxWrapper options={['foo', 'bar']} autoselect />,
+          );
+          getByRole('combobox').focus();
+          await userEvent.type(document.activeElement, 'foo');
+          fireEvent.keyDown(getByRole('combobox'), { key: 'h', ctrlKey: true });
+          fireEvent.change(getByRole('combobox'), { target: { value: 'fo' } });
+          expectToBeOpen(getByRole('combobox'));
+        });
+      });
+
+      describe('ctrl+k', () => {
+        it('does not auto-select an option', async () => {
+          const { getByRole } = render(
+            <ComboBoxWrapper options={['foo', 'bar']} autoselect />,
+          );
+          getByRole('combobox').focus();
+          await userEvent.type(document.activeElement, 'fo');
+          fireEvent.keyDown(getByRole('combobox'), { key: 'k', ctrlKey: true });
+          fireEvent.change(getByRole('combobox'), { target: { value: 'fo' } });
+          expectToBeOpen(getByRole('combobox'));
+        });
+      });
+    });
+  });
+});

--- a/src/components/combo_box.safari.test.jsx
+++ b/src/components/combo_box.safari.test.jsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import { render, fireEvent } from '@testing-library/react';
+
+Object.defineProperties(global.navigator, {
+  vendor: {
+    get() {
+      return 'Apple Computers, Inc.';
+    },
+  },
+});
+
+const { ComboBox } = require('./combo_box');
+
+function ComboBoxWrapper(props) {
+  const [value, onValue] = useState(null);
+  return (
+    <ComboBox
+      id="id"
+      aria-labelledby="id-label"
+      value={value}
+      onValue={onValue}
+      {...props}
+    />
+  );
+}
+
+it('uses managedFocus = true on a mac in safari', () => {
+  const { getByRole, getAllByRole } = render(
+    <ComboBoxWrapper options={['foo', 'bar']} />,
+  );
+  const comboBox = getByRole('combobox');
+  comboBox.focus();
+  fireEvent.keyDown(comboBox, { key: 'ArrowDown' });
+  fireEvent.keyDown(comboBox, { key: 'ArrowDown' });
+  expect(getAllByRole('option')[1]).toHaveFocus();
+});

--- a/src/components/combo_box.test.jsx
+++ b/src/components/combo_box.test.jsx
@@ -204,55 +204,26 @@ describe('options', () => {
         });
 
         describe('pressing the home key', () => {
-          describe('on a mac', () => {
-            it('moves to the first option with the home key', () => {
-              jest.spyOn(navigator, 'platform', 'get').mockImplementation(() => 'MacIntel');
-              const { getByRole, getAllByRole } = render((
-                <ComboBoxWrapper options={options} />
-              ));
-              getByRole('combobox').focus();
-              fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-              fireEvent.keyDown(document.activeElement, { key: 'Home' });
-              expectToHaveFocusedOption(getByRole('combobox'), getAllByRole('option')[0]);
-            });
-          });
-
-          describe('on other systems', () => {
-            it('moves focus back to the list box', () => {
-              const { getByRole } = render((
-                <ComboBoxWrapper options={options} />
-              ));
-              getByRole('combobox').focus();
-              fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-              fireEvent.keyDown(document.activeElement, { key: 'Home' });
-              expectToBeOpen(getByRole('combobox'));
-            });
+          it('moves focus back to the list box', () => {
+            const { getByRole } = render((
+              <ComboBoxWrapper options={options} />
+            ));
+            getByRole('combobox').focus();
+            fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+            fireEvent.keyDown(document.activeElement, { key: 'Home' });
+            expectToBeOpen(getByRole('combobox'));
           });
         });
 
         describe('pressing the end key', () => {
-          describe('on a mac', () => {
-            it('moves to the last option with the end key', () => {
-              jest.spyOn(navigator, 'platform', 'get').mockImplementation(() => 'MacIntel');
-              const { getByRole, getAllByRole } = render((
-                <ComboBoxWrapper options={options} />
-              ));
-              getByRole('combobox').focus();
-              fireEvent.keyDown(document.activeElement, { key: 'End' });
-              expectToHaveFocusedOption(getByRole('combobox'), getAllByRole('option')[2]);
-            });
-          });
-
-          describe('on other systems', () => {
-            it('moves focus back to the list box', () => {
-              const { getByRole, getAllByRole } = render((
-                <ComboBoxWrapper options={options} />
-              ));
-              getByRole('combobox').focus();
-              fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-              fireEvent.keyDown(document.activeElement, { key: 'End' });
-              expectToHaveSelectedOption(getByRole('combobox'), getAllByRole('option')[0]);
-            });
+          it('moves focus back to the list box', () => {
+            const { getByRole, getAllByRole } = render((
+              <ComboBoxWrapper options={options} />
+            ));
+            getByRole('combobox').focus();
+            fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+            fireEvent.keyDown(document.activeElement, { key: 'End' });
+            expectToHaveSelectedOption(getByRole('combobox'), getAllByRole('option')[0]);
           });
         });
 
@@ -317,56 +288,26 @@ describe('options', () => {
         });
 
         describe('pressing Ctrl+d', () => {
-          describe('on a mac', () => {
-            it('moves focus back to the list box removing the selected option', () => {
-              jest.spyOn(navigator, 'platform', 'get').mockImplementation(() => 'MacIntel');
-              const { getByRole } = render((
-                <ComboBoxWrapper options={options} />
-              ));
-              getByRole('combobox').focus();
-              fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-              fireEvent.keyDown(document.activeElement, { key: 'd', ctrlKey: true });
-              expectToBeOpen(getByRole('combobox'));
-            });
-          });
-
-          describe('on other systems', () => {
-            it('moves focus back to the list box removing the selected option', () => {
-              const { getByRole, getAllByRole } = render((
-                <ComboBoxWrapper options={options} />
-              ));
-              getByRole('combobox').focus();
-              fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-              fireEvent.keyDown(document.activeElement, { key: 'd', ctrlKey: true });
-              expectToHaveSelectedOption(getByRole('combobox'), getAllByRole('option')[0]);
-            });
+          it('moves focus back to the list box removing the selected option', () => {
+            const { getByRole, getAllByRole } = render((
+              <ComboBoxWrapper options={options} />
+            ));
+            getByRole('combobox').focus();
+            fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+            fireEvent.keyDown(document.activeElement, { key: 'd', ctrlKey: true });
+            expectToHaveSelectedOption(getByRole('combobox'), getAllByRole('option')[0]);
           });
         });
 
         describe('pressing Ctrl+k', () => {
-          describe('on a mac', () => {
-            it('moves focus back to the list box removing the selected option', () => {
-              jest.spyOn(navigator, 'platform', 'get').mockImplementation(() => 'MacIntel');
-              const { getByRole } = render((
-                <ComboBoxWrapper options={options} />
-              ));
-              getByRole('combobox').focus();
-              fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-              fireEvent.keyDown(document.activeElement, { key: 'k', ctrlKey: true });
-              expectToBeOpen(getByRole('combobox'));
-            });
-          });
-
-          describe('on other systems', () => {
-            it('moves focus back to the list box removing the selected option', () => {
-              const { getByRole, getAllByRole } = render((
-                <ComboBoxWrapper options={options} />
-              ));
-              getByRole('combobox').focus();
-              fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-              fireEvent.keyDown(document.activeElement, { key: 'k', ctrlKey: true });
-              expectToHaveSelectedOption(getByRole('combobox'), getAllByRole('option')[0]);
-            });
+          it('moves focus back to the list box removing the selected option', () => {
+            const { getByRole, getAllByRole } = render((
+              <ComboBoxWrapper options={options} />
+            ));
+            getByRole('combobox').focus();
+            fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+            fireEvent.keyDown(document.activeElement, { key: 'k', ctrlKey: true });
+            expectToHaveSelectedOption(getByRole('combobox'), getAllByRole('option')[0]);
           });
         });
       });
@@ -648,42 +589,6 @@ describe('options', () => {
             fireEvent.keyDown(document.activeElement, { key: 'ArrowUp', altKey: true });
             fireEvent.keyDown(document.activeElement, { key: 'Enter' });
             expect(spy).not.toHaveBeenCalled();
-          });
-        });
-
-        describe('pressing the Home key', () => {
-          describe('on a mac', () => {
-            it('does not change the option', () => {
-              jest.spyOn(navigator, 'platform', 'get').mockImplementation(() => 'MacIntel');
-              const { getByRole, getAllByRole } = render((
-                <ComboBoxWrapper options={options} />
-              ));
-              getByRole('combobox').focus();
-              fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-              fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-              fireEvent.keyDown(document.activeElement, { key: 'Enter' });
-              fireEvent.keyDown(document.activeElement, { key: 'Home' });
-              fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-              expectToHaveFocusedOption(getByRole('combobox'), getAllByRole('option')[1]);
-            });
-          });
-        });
-
-        describe('pressing the End key', () => {
-          describe('on a mac', () => {
-            it('does not change the option', () => {
-              jest.spyOn(navigator, 'platform', 'get').mockImplementation(() => 'MacIntel');
-              const { getByRole, getAllByRole } = render((
-                <ComboBoxWrapper options={options} />
-              ));
-              getByRole('combobox').focus();
-              fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-              fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-              fireEvent.keyDown(document.activeElement, { key: 'Enter' });
-              fireEvent.keyDown(document.activeElement, { key: 'End' });
-              fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-              expectToHaveFocusedOption(getByRole('combobox'), getAllByRole('option')[1]);
-            });
           });
         });
 
@@ -1845,29 +1750,14 @@ describe('autoselect', () => {
       });
 
       describe('ctrl+d', () => {
-        describe('on a mac', () => {
-          it('does not auto-select an option', async () => {
-            jest.spyOn(navigator, 'platform', 'get').mockImplementation(() => 'MacIntel');
-            const { getByRole } = render(
-              <ComboBoxWrapper options={['foo', 'bar']} autoselect />,
-            );
-            getByRole('combobox').focus();
-            await userEvent.type(document.activeElement, 'fo');
-            fireEvent.keyDown(getByRole('combobox'), { key: 'd', ctrlKey: true });
-            expectToBeOpen(getByRole('combobox'));
-          });
-        });
-
-        describe('on other systems', () => {
-          it('continues to auto-select an option', async () => {
-            const { getByRole, getAllByRole } = render(
-              <ComboBoxWrapper options={['food', 'bar']} autoselect />,
-            );
-            getByRole('combobox').focus();
-            await userEvent.type(document.activeElement, 'foo');
-            fireEvent.keyDown(getByRole('combobox'), { key: 'd', ctrlKey: true });
-            expectToHaveSelectedOption(getByRole('combobox'), getAllByRole('option')[0]);
-          });
+        it('continues to auto-select an option', async () => {
+          const { getByRole, getAllByRole } = render(
+            <ComboBoxWrapper options={['food', 'bar']} autoselect />,
+          );
+          getByRole('combobox').focus();
+          await userEvent.type(document.activeElement, 'foo');
+          fireEvent.keyDown(getByRole('combobox'), { key: 'd', ctrlKey: true });
+          expectToHaveSelectedOption(getByRole('combobox'), getAllByRole('option')[0]);
         });
       });
     });
@@ -1885,60 +1775,28 @@ describe('autoselect', () => {
       });
 
       describe('ctrl+h', () => {
-        describe('on a mac', () => {
-          it('does not auto-select an option', async () => {
-            jest.spyOn(navigator, 'platform', 'get').mockImplementation(() => 'MacIntel');
-            const { getByRole } = render(
-              <ComboBoxWrapper options={['foo', 'bar']} autoselect />,
-            );
-            getByRole('combobox').focus();
-            await userEvent.type(document.activeElement, 'foo');
-            fireEvent.keyDown(getByRole('combobox'), { key: 'h', ctrlKey: true });
-            fireEvent.change(getByRole('combobox'), { target: { value: 'fo' } });
-            expectToBeOpen(getByRole('combobox'));
-          });
-        });
-
-        describe('on other systems', () => {
-          it('continues to auto-select an option', async () => {
-            const { getByRole, getAllByRole } = render(
-              <ComboBoxWrapper options={['fooh', 'bar']} autoselect />,
-            );
-            getByRole('combobox').focus();
-            await userEvent.type(document.activeElement, 'foo');
-            fireEvent.keyDown(getByRole('combobox'), { key: 'h', ctrlKey: true });
-            fireEvent.change(getByRole('combobox'), { target: { value: 'fooh' } });
-            expectToHaveSelectedOption(getByRole('combobox'), getAllByRole('option')[0]);
-          });
+        it('continues to auto-select an option', async () => {
+          const { getByRole, getAllByRole } = render(
+            <ComboBoxWrapper options={['fooh', 'bar']} autoselect />,
+          );
+          getByRole('combobox').focus();
+          await userEvent.type(document.activeElement, 'foo');
+          fireEvent.keyDown(getByRole('combobox'), { key: 'h', ctrlKey: true });
+          fireEvent.change(getByRole('combobox'), { target: { value: 'fooh' } });
+          expectToHaveSelectedOption(getByRole('combobox'), getAllByRole('option')[0]);
         });
       });
 
       describe('ctrl+k', () => {
-        describe('on a mac', () => {
-          it('does not auto-select an option', async () => {
-            jest.spyOn(navigator, 'platform', 'get').mockImplementation(() => 'MacIntel');
-            const { getByRole } = render(
-              <ComboBoxWrapper options={['foo', 'bar']} autoselect />,
-            );
-            getByRole('combobox').focus();
-            await userEvent.type(document.activeElement, 'fo');
-            fireEvent.keyDown(getByRole('combobox'), { key: 'k', ctrlKey: true });
-            fireEvent.change(getByRole('combobox'), { target: { value: 'fo' } });
-            expectToBeOpen(getByRole('combobox'));
-          });
-        });
-
-        describe('on other systems', () => {
-          it('continues to auto-select an option', async () => {
-            const { getByRole, getAllByRole } = render(
-              <ComboBoxWrapper options={['fook', 'bar']} autoselect />,
-            );
-            getByRole('combobox').focus();
-            await userEvent.type(document.activeElement, 'foo');
-            fireEvent.keyDown(getByRole('combobox'), { key: 'k', ctrlKey: true });
-            fireEvent.change(getByRole('combobox'), { target: { value: 'fok' } });
-            expectToHaveSelectedOption(getByRole('combobox'), getAllByRole('option')[0]);
-          });
+        it('continues to auto-select an option', async () => {
+          const { getByRole, getAllByRole } = render(
+            <ComboBoxWrapper options={['fook', 'bar']} autoselect />,
+          );
+          getByRole('combobox').focus();
+          await userEvent.type(document.activeElement, 'foo');
+          fireEvent.keyDown(getByRole('combobox'), { key: 'k', ctrlKey: true });
+          fireEvent.change(getByRole('combobox'), { target: { value: 'fok' } });
+          expectToHaveSelectedOption(getByRole('combobox'), getAllByRole('option')[0]);
         });
       });
 
@@ -2704,34 +2562,6 @@ describe('skipOption', () => {
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
     expectToHaveFocusedOption(getByRole('combobox'), getAllByRole('option')[0]);
-  });
-
-  describe('on a mac', () => {
-    it('allows options to be skipped pressing home', () => {
-      jest.spyOn(navigator, 'platform', 'get').mockImplementation(() => 'MacIntel');
-      function skipOption(option) {
-        return option.label === 'Apple';
-      }
-      const { getByRole, getAllByRole } = render(
-        <ComboBoxWrapper options={options} skipOption={skipOption} />,
-      );
-      getByRole('combobox').focus();
-      fireEvent.keyDown(document.activeElement, { key: 'Home' });
-      expectToHaveFocusedOption(getByRole('combobox'), getAllByRole('option')[1]);
-    });
-
-    it('allows options to be skipped pressing end', () => {
-      jest.spyOn(navigator, 'platform', 'get').mockImplementation(() => 'MacIntel');
-      function skipOption(option) {
-        return option.label === 'Orange';
-      }
-      const { getByRole, getAllByRole } = render(
-        <ComboBoxWrapper options={options} skipOption={skipOption} />,
-      );
-      getByRole('combobox').focus();
-      fireEvent.keyDown(document.activeElement, { key: 'End' });
-      expectToHaveFocusedOption(getByRole('combobox'), getAllByRole('option')[1]);
-    });
   });
 });
 

--- a/src/components/combo_box/actions.js
+++ b/src/components/combo_box/actions.js
@@ -1,7 +1,7 @@
 import { nextInList } from '../../helpers/next_in_list';
 import { previousInList } from '../../helpers/previous_in_list';
 import { rNonPrintableKey } from '../../constants/r_non_printable_key';
-import { isMac } from '../../helpers/is_mac';
+import { isMac } from '../../sniffers/is_mac';
 import { getKey } from '../../helpers/get_key';
 
 export const SET_SEARCH = 'SET_SEARCH';
@@ -158,7 +158,8 @@ export function onKeyDown(event) {
         event.preventDefault();
         if (focusedOption && !focusedOption?.unselectable) {
           dispatch(onSelectValue(focusedOption));
-          if (managedFocus) {
+          if (document.activeElement !== inputRef.current) {
+            // Mac Firefox still needs the focus reset even without managedFocus
             inputRef.current.focus();
           }
         }

--- a/src/components/highlight_value.ie.test.jsx
+++ b/src/components/highlight_value.ie.test.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Context } from '../context';
+
+Object.defineProperties(global.navigator, {
+  userAgent: {
+    get() {
+      return 'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko';
+    },
+  },
+});
+
+const { HighlightValue } = require('./highlight_value');
+
+it('does not include the hidden text with IE', () => {
+  const spy = jest.fn(() => ['f', ['o'], 'o']);
+
+  const { container } = render((
+    <Context.Provider value={{ search: 'foo', props: {}, test: 'bar' }}>
+      <HighlightValue highlight={spy} foe="fee" search="fee">
+        foo
+      </HighlightValue>
+    </Context.Provider>
+  ));
+
+  expect(container).toContainHTML('<div>f<mark>o</mark>o</div>');
+});

--- a/src/components/highlight_value.jsx
+++ b/src/components/highlight_value.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Highlight } from './highlight';
 import { Context } from '../context';
+import { isIE } from '../sniffers/is_ie';
 
 function emptyHighlight(highlight) {
   return !highlight.length || (highlight.length === 1 && typeof highlight[0] === 'string');
@@ -13,6 +14,15 @@ export function HighlightValue({ children: value, highlight, inverse, search: _s
 
   if (emptyHighlight(highlighted)) {
     return highlighted.join('');
+  }
+
+  if (isIE()) {
+    // IE ignores aria-hidden, however it also doesn't suffer from the inline element issue
+    return (
+      <Highlight inverse={inverse}>
+        {highlighted}
+      </Highlight>
+    );
   }
 
   // Accessible naming treats inline elements as block and adds additional white space

--- a/src/components/highlight_value.test.jsx
+++ b/src/components/highlight_value.test.jsx
@@ -48,3 +48,17 @@ it('calls highlight with a custom search', () => {
 
   expect(spy).toHaveBeenCalledWith('foo', 'fee', { foe: 'fee' });
 });
+
+it('renders the highlight with hidden text', () => {
+  const spy = jest.fn(() => ['f', ['o'], 'o']);
+
+  const { container } = render((
+    <Context.Provider value={{ search: 'foo', props: {}, test: 'bar' }}>
+      <HighlightValue highlight={spy} foe="fee" search="fee">
+        foo
+      </HighlightValue>
+    </Context.Provider>
+  ));
+
+  expect(container).toContainHTML('<div><span>foo</span><span aria-hidden="true">f<mark>o</mark>o</span></div>');
+});

--- a/src/helpers/get_key.js
+++ b/src/helpers/get_key.js
@@ -1,4 +1,4 @@
-import { isMac } from './is_mac';
+import { isMac } from '../sniffers/is_mac';
 
 export function getKey(event) {
   const { key, ctrlKey, altKey, metaKey } = event;

--- a/src/helpers/is_mac.js
+++ b/src/helpers/is_mac.js
@@ -1,3 +1,0 @@
-export function isMac() {
-  return /mac/i.test(navigator.platform);
-}

--- a/src/sniffers/is_ie.js
+++ b/src/sniffers/is_ie.js
@@ -1,0 +1,8 @@
+let value;
+
+export function isIE() {
+  if (value === undefined) {
+    value = /Trident/i.test(navigator.userAgent);
+  }
+  return value;
+}

--- a/src/sniffers/is_ie.test.js
+++ b/src/sniffers/is_ie.test.js
@@ -1,0 +1,28 @@
+/* eslint-disable global-require */
+
+beforeEach(() => {
+  jest.resetModules();
+});
+
+const agentIE11 = 'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko';
+const agentEdge = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.111 Safari/537.36 Edg/86.0.622.56';
+
+it('is true for ie11', () => {
+  jest.spyOn(navigator, 'userAgent', 'get').mockImplementation(() => agentIE11);
+  const { isIE } = require('./is_ie');
+  expect(isIE()).toEqual(true);
+});
+
+it('is false for edge', () => {
+  jest.spyOn(navigator, 'userAgent', 'get').mockImplementation(() => agentEdge);
+  const { isIE } = require('./is_ie');
+  expect(isIE()).toEqual(false);
+});
+
+it('caches the value', () => {
+  jest.spyOn(navigator, 'userAgent', 'get').mockImplementation(() => agentIE11);
+  const { isIE } = require('./is_ie');
+  expect(isIE()).toEqual(true);
+  jest.spyOn(navigator, 'userAgent', 'get').mockImplementation(() => agentEdge);
+  expect(isIE()).toEqual(true);
+});

--- a/src/sniffers/is_mac.js
+++ b/src/sniffers/is_mac.js
@@ -1,0 +1,8 @@
+let value;
+
+export function isMac() {
+  if (value === undefined) {
+    value = /mac|iphone|ipad|ipod/i.test(navigator.platform);
+  }
+  return value;
+}

--- a/src/sniffers/is_mac.test.js
+++ b/src/sniffers/is_mac.test.js
@@ -1,0 +1,43 @@
+/* eslint-disable global-require */
+
+beforeEach(() => {
+  jest.resetModules();
+});
+
+it('is true for a mac platform', () => {
+  jest.spyOn(navigator, 'platform', 'get').mockImplementation(() => 'MacIntel');
+  const { isMac } = require('./is_mac');
+  expect(isMac()).toEqual(true);
+});
+
+it('is true for the iphone platform', () => {
+  jest.spyOn(navigator, 'platform', 'get').mockImplementation(() => 'iPhone');
+  const { isMac } = require('./is_mac');
+  expect(isMac()).toEqual(true);
+});
+
+it('is true for the ipad platform', () => {
+  jest.spyOn(navigator, 'platform', 'get').mockImplementation(() => 'iPad');
+  const { isMac } = require('./is_mac');
+  expect(isMac()).toEqual(true);
+});
+
+it('is true for the ipod platform', () => {
+  jest.spyOn(navigator, 'platform', 'get').mockImplementation(() => 'iPod');
+  const { isMac } = require('./is_mac');
+  expect(isMac()).toEqual(true);
+});
+
+it('is false for windows', () => {
+  jest.spyOn(navigator, 'platform', 'get').mockImplementation(() => 'Win32');
+  const { isMac } = require('./is_mac');
+  expect(isMac()).toEqual(false);
+});
+
+it('caches the value', () => {
+  jest.spyOn(navigator, 'platform', 'get').mockImplementation(() => 'MacIntel');
+  const { isMac } = require('./is_mac');
+  expect(isMac()).toEqual(true);
+  jest.spyOn(navigator, 'platform', 'get').mockImplementation(() => 'Win32');
+  expect(isMac()).toEqual(true);
+});

--- a/src/sniffers/is_safari.js
+++ b/src/sniffers/is_safari.js
@@ -1,0 +1,8 @@
+let value;
+
+export function isSafari() {
+  if (value === undefined) {
+    value = /apple/i.test(navigator.vendor);
+  }
+  return value;
+}

--- a/src/sniffers/is_safari.test.js
+++ b/src/sniffers/is_safari.test.js
@@ -1,0 +1,31 @@
+/* eslint-disable global-require */
+
+beforeEach(() => {
+  jest.resetModules();
+});
+
+it('is true for an Apple product platform', () => {
+  jest.spyOn(navigator, 'vendor', 'get').mockImplementation(() => 'Apple Computer, Inc.');
+  const { isSafari } = require('./is_safari');
+  expect(isSafari()).toEqual(true);
+});
+
+it('is false for a Google platform', () => {
+  jest.spyOn(navigator, 'vendor', 'get').mockImplementation(() => 'Google Inc.');
+  const { isSafari } = require('./is_safari');
+  expect(isSafari()).toEqual(false);
+});
+
+it('is false for a Mozilla platform', () => {
+  jest.spyOn(navigator, 'vendor', 'get').mockImplementation(() => '');
+  const { isSafari } = require('./is_safari');
+  expect(isSafari()).toEqual(false);
+});
+
+it('caches the value', () => {
+  jest.spyOn(navigator, 'vendor', 'get').mockImplementation(() => 'Apple Computer, Inc.');
+  const { isSafari } = require('./is_safari');
+  expect(isSafari()).toEqual(true);
+  jest.spyOn(navigator, 'vendor', 'get').mockImplementation(() => '');
+  expect(isSafari()).toEqual(true);
+});


### PR DESCRIPTION
Using Chrome / Edge or Firefox on a Mac, managed focus doesn't read out the first option after pressing arrow down.

Instead turn off managed focus for this case.

Note managed focus actually appears to work well for all tested users agents combinations accept Safari and Voice-over.