### PR TITLE
add a space between radio and checkbox label and description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Change log
 
+## 2.4.1
+
+### Fixed
+
+- `<Checkboxes>` and `<Radios>` now have a space between the label and description
+
 ## 2.4.0
 
 ### Added
 
-- `Checkboxes` and `<Radios>` now have a `renderLabelWrapper` option
+- `<Checkboxes>` and `<Radios>` now have a `renderLabelWrapper` option
 
 ## 2.3.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@citizensadvice/react-combo-boxes",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@citizensadvice/react-combo-boxes",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "ISC",
       "dependencies": {
         "shallow-equal": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/react-combo-boxes",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A combo box implementations in React",
   "license": "ISC",
   "author": "Daniel Lewis",

--- a/src/components/checkboxes.jsx
+++ b/src/components/checkboxes.jsx
@@ -119,6 +119,7 @@ export const Checkboxes = memo((rawProps) => {
                     ),
                     className: makeBEMClass(classPrefix, 'label'),
                   }, { option, checked }, optionisedProps)}
+                  {description && ' '}
                   {!!description && (renderDescription({
                     id: `${key}_description`,
                     children: description,

--- a/src/components/radios.jsx
+++ b/src/components/radios.jsx
@@ -92,6 +92,7 @@ export const Radios = memo((rawProps) => {
                     ),
                     className: makeBEMClass(classPrefix, 'label'),
                   }, { option, checked }, optionisedProps)}
+                  {description && ' '}
                   {!!description && (renderDescription({
                     id: `${key}_description`,
                     children: description,


### PR DESCRIPTION
`<Checkboxes>` and `<Radios>` now have a space between the label and description
