### PR TITLE
Release 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Fixed
+### 2.6.0
 
 - Simplification of how focus is managed to fix issues with the focus jumping back when tabbing from a combo-box
 - The remove cross will no longer show if a selected option's label is blank

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@citizensadvice/react-combo-boxes",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@citizensadvice/react-combo-boxes",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "license": "ISC",
       "dependencies": {
         "marked-highlight": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/react-combo-boxes",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "A combo box implementations in React",
   "license": "ISC",
   "author": "Daniel Lewis",


### PR DESCRIPTION
- Simplification of how focus is managed to fix issues with the focus jumping back when tabbing from a combo-box
- The remove cross will no longer show if a selected option's label is blank
- Search suggestions example was not displaying any options