### PR TITLE
release 2.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@citizensadvice/react-combo-boxes",
-  "version": "2.7.0-rc.3",
+  "version": "2.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@citizensadvice/react-combo-boxes",
-      "version": "2.7.0-rc.3",
+      "version": "2.7.0",
       "license": "ISC",
       "dependencies": {
         "shallow-equal": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/react-combo-boxes",
-  "version": "2.7.0-rc.3",
+  "version": "2.7.0",
   "description": "A combo box implementations in React",
   "license": "ISC",
   "author": "Daniel Lewis",


### PR DESCRIPTION
## Added

- Added a new `layout_popover` to resolves issues displaying list boxes inside
  of scrolling areas or a modal `<dialog>`. This has a peer dependency of floating-ui

## Fixes

- `placeholderOption` should not produce an option for `<Radios>` and `<Checkboxes>`
- layout functions could be called without the listbox or input as null if the ref changed before the animation frame
