### PR TITLE
release 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## Unreleased
+## 2.8.0
 
 ### Changed
 
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- `layout_popover` is not showing the popover in the top layer when in a modal dialog that is opened and closed
+- `layout_popover` is not hiding the popover when a listbox is closed which can result in the listbox not being in the top layer
 
 ## 2.7.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@citizensadvice/react-combo-boxes",
-  "version": "2.8.0-alpha.2",
+  "version": "2.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@citizensadvice/react-combo-boxes",
-      "version": "2.8.0-alpha.2",
+      "version": "2.8.0",
       "license": "ISC",
       "dependencies": {
         "shallow-equal": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/react-combo-boxes",
-  "version": "2.8.0-alpha.2",
+  "version": "2.8.0",
   "description": "A combo box implementations in React",
   "license": "ISC",
   "author": "Daniel Lewis",


### PR DESCRIPTION
## Changed

- (Potentially breaking): Layout functions are now called when the listbox is hidden,
  allowing clean-up methods to be run

##  Fixed

- `layout_popover` is not hiding the popover when a listbox is closed which can result in the listbox not being in the top layer
