### PR TITLE
Release 2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## Unreleased
+## 2.8.1
 
 - Fix misspelled condition means layout functions are run without the listbox or input
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@citizensadvice/react-combo-boxes",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@citizensadvice/react-combo-boxes",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "license": "ISC",
       "dependencies": {
         "shallow-equal": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/react-combo-boxes",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "A combo box implementations in React",
   "license": "ISC",
   "author": "Daniel Lewis",


### PR DESCRIPTION
Fix a misspelling of `inConnected` was layout functions to be incorrectly called