### PR TITLE
v2.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@citizensadvice/react-combo-boxes",
-  "version": "2.9.0-rc.4",
+  "version": "2.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@citizensadvice/react-combo-boxes",
-      "version": "2.9.0-rc.4",
+      "version": "2.9.0",
       "license": "ISC",
       "dependencies": {
         "shallow-equal": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/react-combo-boxes",
-  "version": "2.9.0-rc.4",
+  "version": "2.9.0",
   "description": "A combo box implementations in React",
   "license": "ISC",
   "author": "Daniel Lewis",


### PR DESCRIPTION
- If the value is updated for a combo-box and the listbox is visible and there is no user entered search, onSearch will be triggered
- React 18.3 support
  - Remove default props in favour of default parameters
  - Fix warnings on spreading `key`
- Remove Node 16 from the test matrix