### PR TITLE
Release 3.0.0 rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Change log
 
-## Unreleased
+## 3.0.0-rc.1
 
+- Updates SASS from @import to @use to fix deprecation warnings (potentially breaking)
+- Updates SASS to fix mixed declaration errors
 - Do not close a combo-box or drop-down if the focus is leaving the browser window
+- Add Node 22 to testing matrix
+- Switch to eslint 9
 
 ## 2.9.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@citizensadvice/react-combo-boxes",
-  "version": "2.9.0",
+  "version": "3.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@citizensadvice/react-combo-boxes",
-      "version": "2.9.0",
+      "version": "3.0.0-rc.1",
       "license": "ISC",
       "dependencies": {
         "shallow-equal": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@citizensadvice/react-combo-boxes",
-  "version": "2.9.0",
+  "version": "3.0.0-rc.1",
   "description": "A combo box implementations in React",
   "license": "ISC",
   "author": "Daniel Lewis",


### PR DESCRIPTION
- Updates SASS from `@import` to `@use` to fix deprecation warnings (potentially breaking)
- Updates SASS to fix mixed declaration errors
- Do not close a combo-box or drop-down if the focus is leaving the browser window
- Add Node 22 to testing matrix
- Switch to eslint 9