### PR TITLE
added tabindex=-1 to listbox table to prevent it becoming an extra tab-stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Unreleased
+
+- Added `tabindex="-1"` to the listbox table container to prevent it becoming an extra tab-stop
+
 ## 3.0.0
 
 - Updates SASS from @import to @use to fix deprecation warnings (potentially breaking)

--- a/src/components/__snapshots__/combo_box_table.test.jsx.snap
+++ b/src/components/__snapshots__/combo_box_table.test.jsx.snap
@@ -35,6 +35,7 @@ exports[`cells with class names renders a table with colgroups 1`] = `
     <div
       class="react-combo-boxes-combobox__listbox react-combo-boxes-combobox__listbox--header"
       hidden=""
+      tabindex="-1"
     >
       <table
         aria-labelledby="id-label"
@@ -251,6 +252,7 @@ exports[`cells with html renders a table with colgroups 1`] = `
     <div
       class="react-combo-boxes-combobox__listbox react-combo-boxes-combobox__false"
       hidden=""
+      tabindex="-1"
     >
       <table
         aria-labelledby="id-label"
@@ -417,6 +419,7 @@ exports[`columns as names only renders a table as the list box 1`] = `
     <div
       class="react-combo-boxes-combobox__listbox react-combo-boxes-combobox__false"
       hidden=""
+      tabindex="-1"
     >
       <table
         aria-labelledby="id-label"
@@ -613,6 +616,7 @@ exports[`columns with headers renders a table with headers 1`] = `
     <div
       class="react-combo-boxes-combobox__listbox react-combo-boxes-combobox__listbox--header"
       hidden=""
+      tabindex="-1"
     >
       <table
         aria-labelledby="id-label"
@@ -829,6 +833,7 @@ exports[`columns with html renders a table with colgroups 1`] = `
     <div
       class="react-combo-boxes-combobox__listbox react-combo-boxes-combobox__false"
       hidden=""
+      tabindex="-1"
     >
       <table
         aria-labelledby="id-label"
@@ -999,6 +1004,7 @@ exports[`grouped renders a table with groups 1`] = `
     <div
       class="react-combo-boxes-combobox__listbox react-combo-boxes-combobox__false"
       hidden=""
+      tabindex="-1"
     >
       <table
         aria-labelledby="id-label"

--- a/src/components/__snapshots__/drop_down_table.test.jsx.snap
+++ b/src/components/__snapshots__/drop_down_table.test.jsx.snap
@@ -23,6 +23,7 @@ exports[`cells with html renders a table with colgroups 1`] = `
       <div
         class="react-combo-boxes-dropdown__listbox react-combo-boxes-dropdown__false"
         hidden=""
+        tabindex="-1"
       >
         <table
           aria-labelledby="id-label"
@@ -174,6 +175,7 @@ exports[`columns as names only renders a table as the list box 1`] = `
       <div
         class="react-combo-boxes-dropdown__listbox react-combo-boxes-dropdown__false"
         hidden=""
+        tabindex="-1"
       >
         <table
           aria-labelledby="id-label"
@@ -355,6 +357,7 @@ exports[`columns with headers renders a table with headers 1`] = `
       <div
         class="react-combo-boxes-dropdown__listbox react-combo-boxes-dropdown__listbox--header"
         hidden=""
+        tabindex="-1"
       >
         <table
           aria-labelledby="id-label"
@@ -556,6 +559,7 @@ exports[`columns with html renders a table with colgroups 1`] = `
       <div
         class="react-combo-boxes-dropdown__listbox react-combo-boxes-dropdown__false"
         hidden=""
+        tabindex="-1"
       >
         <table
           aria-labelledby="id-label"
@@ -711,6 +715,7 @@ exports[`grouped renders a table with groups 1`] = `
       <div
         class="react-combo-boxes-dropdown__listbox react-combo-boxes-dropdown__false"
         hidden=""
+        tabindex="-1"
       >
         <table
           aria-labelledby="id-label"

--- a/src/components/list_box_table/render_list_box.jsx
+++ b/src/components/list_box_table/render_list_box.jsx
@@ -24,6 +24,7 @@ export function renderListBox(
         hasHeader && 'listbox--header',
       ),
       onMouseDown: (e) => e.preventDefault(),
+      tabIndex: -1,
       ref,
       children: renderTable(
         {


### PR DESCRIPTION
It is a scrollable container, and it it scrolls it becomes a tab stop in some browsers.

As there is a different mechanism for scrolling the container this is undesirable.