### PR TITLE
Remove nbsp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Remove non-breaking space separators between options as the Mac Chrome bug requiring this has been resolved
+- Use aria-labelledby for all option labels instead of inserting visually hidden text
 
 ## 3.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Unreleased
+
+- Remove non-breaking space separators between options as the Mac Chrome bug requiring this has been resolved
+
 ## 3.0.2
 
 - Fix stylelint-config-standard-scss was accidentally added to dependencies instead of devDependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## Unreleased
 
 - Remove non-breaking space separators between options as the Mac Chrome bug requiring this has been resolved
+- Removes the `renderGroupAccessibleLabel` and `renderTableCellColumnAccessibleLabel` from combo-boxes and drop downs as these are no longer required
 - Use aria-labelledby for all option labels instead of inserting visually hidden text
+- Fix an issue where drop down aria-live message was prefixed with "undefined"
 
 ## 3.0.2
 

--- a/docs/combo_box.md
+++ b/docs/combo_box.md
@@ -234,21 +234,20 @@ Each render method has the signature
 
 The render functions available are:
 
-| Name                         | Default value                                              | Description                                                                        |
-| ---------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `renderWrapper`              | `(props) => <div {...props} />`                            | Renders the component wrapper                                                      |
-| `renderInput`                | `(props) => <input {...props} />`                          | Renders the combo-box input                                                        |
-| `renderDownArrow`            | `(props) => <span {...props} />`                           | Renders down arrow displayed when options are available                            |
-| `renderClearButton`          | `(props) => <span {...props} />`                           | Renders '×' button displayed when an option is selected                            |
-| `renderListBox`              | `(props) => <ul {...props} />`                             | Renders the list-box                                                               |
-| `renderGroup`                | `({ key, ...props }) => <Fragment key={key} {...props} />` | Wraps a group of options                                                           |
-| `renderGroupAccessibleLabel` | `(props) => <span {...props} />`                           | Renders the accessible label for a group. This will be read out before each option |
-| `renderGroupLabel`           | `(props) => <li {...props} />`                             | Renders the group including the options. This will be ignored by a screen-reader   |
-| `renderGroupName`            | `(props) => <Fragment {...props} />`                       | Renders the name of the group. This will be ignored by a screen-reader             |
-| `renderOption`               | `({ key, ...props }) => <li key={key} {...props} />`       | Renders an option                                                                  |
-| `renderValue`                | `(props) => <Fragment {...props} />`                       | Renders the value within an option. See [Highlighters][highlighters].              |
-| `renderNotFound`             | `(props) => <div {...props} />`                            | Renders the not found message                                                      |
-| `renderAriaDescription`      | `(props) => <div {...props} />`                            | Renders the assistive hint of the combo box                                        |
+| Name                    | Default value                                              | Description                                                           |
+| ----------------------- | ---------------------------------------------------------- | --------------------------------------------------------------------- |
+| `renderWrapper`         | `(props) => <div {...props} />`                            | Renders the component wrapper                                         |
+| `renderInput`           | `(props) => <input {...props} />`                          | Renders the combo-box input                                           |
+| `renderDownArrow`       | `(props) => <span {...props} />`                           | Renders down arrow displayed when options are available               |
+| `renderClearButton`     | `(props) => <span {...props} />`                           | Renders '×' button displayed when an option is selected               |
+| `renderListBox`         | `(props) => <ul {...props} />`                             | Renders the list-box                                                  |
+| `renderGroup`           | `({ key, ...props }) => <Fragment key={key} {...props} />` | Wraps a group of options                                              |
+| `renderGroupLabel`      | `(props) => <li {...props} />`                             | Renders the group including the options.                              |
+| `renderGroupName`       | `(props) => <Fragment {...props} />`                       | Renders the name of the group.                                        |
+| `renderOption`          | `({ key, ...props }) => <li key={key} {...props} />`       | Renders an option                                                     |
+| `renderValue`           | `(props) => <Fragment {...props} />`                       | Renders the value within an option. See [Highlighters][highlighters]. |
+| `renderNotFound`        | `(props) => <div {...props} />`                            | Renders the not found message                                         |
+| `renderAriaDescription` | `(props) => <div {...props} />`                            | Renders the assistive hint of the combo box                           |
 
 #### `onLayoutListBox: (listbox: Element) => void | []<(listbox: Element) => void>`
 

--- a/docs/combo_box_table.md
+++ b/docs/combo_box_table.md
@@ -51,23 +51,21 @@ of `column: { label: string, name: string }` on the state.
 
 The render functions available are:
 
-| Name                                   | Default                                              | Description                                                                        |
-| -------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `renderWrapper`                        | `(props) => <div {...props} />`                      | Renders the component wrapper                                                      |
-| `renderInput`                          | `(props) => <input {...props} />`                    | Renders the combo-box input                                                        |
-| `renderDownArrow`                      | `(props) => <span {...props} />`                     | Renders down arrow displayed when options are available                            |
-| `renderClearButton`                    | `(props) => <span {...props} />`                     | Renders '×' button displayed when an option is selected                            |
-| `renderTableWrapper`                   | `(props) => <div {...props} />`                      | Renders the element containing the table                                           |
-| `renderTable`                          | `(props) => <table {...props} />`                    | Renders a table, which is the list box                                             |
-| `renderTableHeaderCell`                | `({ key, ...props }) => <th key={key} {...props} />` | Renders a thead header cell with a column name                                     |
-| `renderTableGroupRow`                  | `(props) => <tr {...props} />`                       | Renders a row containing a group header                                            |
-| `renderTableGroupHeaderCell`           | `({ key, ...props }) => <th key={key} {...props} />` | Renders a cell containing the group label. This will be ignored by a screen-reader |
-| `renderTableRow`                       | `({ key, ...props }) => <tr key={key} {...props} />` | Renders a table row, which is a list box option                                    |
-| `renderTableCell`                      | `({ key, ...props }) => <th key={key} {...props} />` | Renders a table cell, one cell is rendered for each column                         |
-| `renderGroupAccessibleLabel`           | `(props) => <span {...props} />`                     | Renders the accessible label for a group. This will be read out before each option |
-| `renderTableCellColumnAccessibleLabel` | `(props) => <span {...props} />`                     | Renders the accessible label for column. This will be read out before each option  |
-| `renderColumnValue`                    | `(props) => <Fragment {...props} />`                 | Renders the value within a table cell                                              |
-| `renderNotFound`                       | `(props) => <div {...props} />`                      | Renders the not found message                                                      |
-| `renderAriaDescription`                | `(props) => <div {...props} />`                      | Renders the aria description of the combo box                                      |
+| Name                         | Default                                              | Description                                                                        |
+| ---------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `renderWrapper`              | `(props) => <div {...props} />`                      | Renders the component wrapper                                                      |
+| `renderInput`                | `(props) => <input {...props} />`                    | Renders the combo-box input                                                        |
+| `renderDownArrow`            | `(props) => <span {...props} />`                     | Renders down arrow displayed when options are available                            |
+| `renderClearButton`          | `(props) => <span {...props} />`                     | Renders '×' button displayed when an option is selected                            |
+| `renderTableWrapper`         | `(props) => <div {...props} />`                      | Renders the element containing the table                                           |
+| `renderTable`                | `(props) => <table {...props} />`                    | Renders a table, which is the list box                                             |
+| `renderTableHeaderCell`      | `({ key, ...props }) => <th key={key} {...props} />` | Renders a thead header cell with a column name                                     |
+| `renderTableGroupRow`        | `(props) => <tr {...props} />`                       | Renders a row containing a group header                                            |
+| `renderTableGroupHeaderCell` | `({ key, ...props }) => <th key={key} {...props} />` | Renders a cell containing the group label. This will be ignored by a screen-reader |
+| `renderTableRow`             | `({ key, ...props }) => <tr key={key} {...props} />` | Renders a table row, which is a list box option                                    |
+| `renderTableCell`            | `({ key, ...props }) => <th key={key} {...props} />` | Renders a table cell, one cell is rendered for each column                         |
+| `renderColumnValue`          | `(props) => <Fragment {...props} />`                 | Renders the value within a table cell                                              |
+| `renderNotFound`             | `(props) => <div {...props} />`                      | Renders the not found message                                                      |
+| `renderAriaDescription`      | `(props) => <div {...props} />`                      | Renders the aria description of the combo box                                      |
 
 [aria-practices-combo-box-grid]: https://w3c.github.io/aria-practices/#grid-popup-keyboard-interaction

--- a/examples/combo_box/aria_1_2_groups/index.jsx
+++ b/examples/combo_box/aria_1_2_groups/index.jsx
@@ -32,6 +32,15 @@ function renderGroup(props, { groupChildren, group: { key, label } }) {
   );
 }
 
+function renderOption({ key, 'aria-labelledby': _, ...props }) {
+  return (
+    <li
+      key={key}
+      {...props}
+    />
+  );
+}
+
 export function Example() {
   const [value, setValue] = useState(null);
   const [search, setSearch] = useState(null);
@@ -55,7 +64,7 @@ export function Example() {
         options={filteredOptions}
         managedFocus={managedFocus}
         renderGroup={renderGroup}
-        renderGroupAccessibleLabel={() => null}
+        renderOption={renderOption}
       />
 
       <label>

--- a/examples/drop_down_table/drop_down_grouped_headers/README.md
+++ b/examples/drop_down_table/drop_down_grouped_headers/README.md
@@ -1,0 +1,3 @@
+# Drop down table with headers and grouped
+
+A drop down with both headers and group labels.

--- a/examples/drop_down_table/drop_down_grouped_headers/index.jsx
+++ b/examples/drop_down_table/drop_down_grouped_headers/index.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import {
   DropDownTable,
   layoutMaxWidth,
@@ -16,8 +16,8 @@ const columns = [
   { name: 'pattern', label: 'Pattern' },
 ];
 
-function mapOption({ breed }) {
-  return { label: breed };
+function mapOption({ breed, bodyType }) {
+  return { label: breed, group: bodyType };
 }
 
 const onLayoutListBox = [
@@ -28,27 +28,24 @@ const onLayoutListBox = [
 
 export function Example() {
   const [value, setValue] = useState(null);
-  const ref = useRef();
 
   return (
     <>
-      <div
-        className="label"
-        onClick={() => ref.current.focus()}
+      <label
         id="drop-down-label"
+        htmlFor="select"
       >
-        Drop down
-      </div>
+        Select
+      </label>
       <DropDownTable
         id="drop-down"
         aria-labelledby="drop-down-label"
-        ref={ref}
         value={value}
         onValue={setValue}
-        onLayoutListBox={onLayoutListBox}
-        options={cats}
         columns={columns}
+        options={cats}
         mapOption={mapOption}
+        onLayoutListBox={onLayoutListBox}
       />
 
       <label htmlFor="output">Current value</label>

--- a/examples/drop_down_table/drop_down_grouped_headers/index.pug
+++ b/examples/drop_down_table/drop_down_grouped_headers/index.pug
@@ -1,0 +1,14 @@
+extends ../../layout.pug
+
+block variables
+  - const title = 'Drop down table with headers and groups'
+  - const example = 'drop_down_table/drop_down_grouped_headers'
+
+block main
+  include:markdown README.md
+
+  div(data-react-example=example)
+
+  pre.language-js
+    code.language-js
+      include:highlight:packageInclude index.jsx

--- a/examples/side_bar.pug
+++ b/examples/side_bar.pug
@@ -103,6 +103,7 @@ nav
       +link('/examples/drop_down_table/drop_down/index.pug') Table
       +link('/examples/drop_down_table/drop_down_headers/index.pug') With headers
       +link('/examples/drop_down_table/drop_down_grouped/index.pug') Grouped
+      +link('/examples/drop_down_table/drop_down_grouped_headers/index.pug') With headers and grouped
   details
     summary Radios
     +link('/examples/radios.pug') About

--- a/src/components/__snapshots__/combo_box.test.jsx.snap
+++ b/src/components/__snapshots__/combo_box.test.jsx.snap
@@ -224,65 +224,51 @@ exports[`options as array of objects group renders grouped options 1`] = `
       <li
         aria-hidden="true"
         class="react-combo-boxes-combobox__group-label"
+        id="id_group_citrus"
       >
         Citrus
       </li>
       <li
+        aria-labelledby="id_group_citrus id_option_orange"
         class="react-combo-boxes-combobox__option"
         id="id_option_orange"
         role="option"
         tabindex="-1"
       >
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-          Citrus 
-        </span>
         Orange
       </li>
       <li
+        aria-labelledby="id_group_citrus id_option_lemon"
         class="react-combo-boxes-combobox__option"
         id="id_option_lemon"
         role="option"
         tabindex="-1"
       >
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-          Citrus 
-        </span>
         Lemon
       </li>
       <li
         aria-hidden="true"
         class="react-combo-boxes-combobox__group-label"
+        id="id_group_berry"
       >
         Berry
       </li>
       <li
+        aria-labelledby="id_group_berry id_option_raspberry"
         class="react-combo-boxes-combobox__option"
         id="id_option_raspberry"
         role="option"
         tabindex="-1"
       >
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-          Berry 
-        </span>
         Raspberry
       </li>
       <li
+        aria-labelledby="id_group_berry id_option_strawberry"
         class="react-combo-boxes-combobox__option"
         id="id_option_strawberry"
         role="option"
         tabindex="-1"
       >
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-          Berry 
-        </span>
         Strawberry
       </li>
     </ul>

--- a/src/components/__snapshots__/combo_box.test.jsx.snap
+++ b/src/components/__snapshots__/combo_box.test.jsx.snap
@@ -46,11 +46,6 @@ exports[`onSearch updating options updates the displayed options 1`] = `
         tabindex="-1"
       >
         Strawberry
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
       <li
         class="react-combo-boxes-combobox__option"
@@ -59,11 +54,6 @@ exports[`onSearch updating options updates the displayed options 1`] = `
         tabindex="-1"
       >
         Raspberry
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
       <li
         class="react-combo-boxes-combobox__option"
@@ -72,11 +62,6 @@ exports[`onSearch updating options updates the displayed options 1`] = `
         tabindex="-1"
       >
         Banana
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
     </ul>
     <div
@@ -151,11 +136,6 @@ exports[`options as array of objects disabled sets the aria-disabled attribute 1
         tabindex="-1"
       >
         Apple
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
       <li
         aria-disabled="true"
@@ -165,11 +145,6 @@ exports[`options as array of objects disabled sets the aria-disabled attribute 1
         tabindex="-1"
       >
         Banana
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
     </ul>
     <div
@@ -245,11 +220,6 @@ exports[`options as array of objects group renders grouped options 1`] = `
         tabindex="-1"
       >
         Apple
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
       <li
         aria-hidden="true"
@@ -266,14 +236,9 @@ exports[`options as array of objects group renders grouped options 1`] = `
         <span
           class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
         >
-          Citrus 
+          Citrus 
         </span>
         Orange
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
       <li
         class="react-combo-boxes-combobox__option"
@@ -284,14 +249,9 @@ exports[`options as array of objects group renders grouped options 1`] = `
         <span
           class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
         >
-          Citrus 
+          Citrus 
         </span>
         Lemon
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
       <li
         aria-hidden="true"
@@ -308,14 +268,9 @@ exports[`options as array of objects group renders grouped options 1`] = `
         <span
           class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
         >
-          Berry 
+          Berry 
         </span>
         Raspberry
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
       <li
         class="react-combo-boxes-combobox__option"
@@ -326,14 +281,9 @@ exports[`options as array of objects group renders grouped options 1`] = `
         <span
           class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
         >
-          Berry 
+          Berry 
         </span>
         Strawberry
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
     </ul>
     <div
@@ -409,11 +359,6 @@ exports[`options as array of objects label renders a closed combo box 1`] = `
         tabindex="-1"
       >
         Apple
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
       <li
         class="react-combo-boxes-combobox__option"
@@ -422,11 +367,6 @@ exports[`options as array of objects label renders a closed combo box 1`] = `
         tabindex="-1"
       >
         Banana
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
       <li
         class="react-combo-boxes-combobox__option"
@@ -435,11 +375,6 @@ exports[`options as array of objects label renders a closed combo box 1`] = `
         tabindex="-1"
       >
         Orange
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
     </ul>
     <div
@@ -513,13 +448,7 @@ exports[`options as array of objects missing label treats as undefined 1`] = `
         id="id_option_"
         role="option"
         tabindex="-1"
-      >
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
-      </li>
+      />
     </ul>
     <div
       class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
@@ -594,11 +523,6 @@ exports[`options options as array of numbers renders a closed combo box 1`] = `
         tabindex="-1"
       >
         1
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
       <li
         class="react-combo-boxes-combobox__option"
@@ -607,11 +531,6 @@ exports[`options options as array of numbers renders a closed combo box 1`] = `
         tabindex="-1"
       >
         2
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
       <li
         class="react-combo-boxes-combobox__option"
@@ -620,11 +539,6 @@ exports[`options options as array of numbers renders a closed combo box 1`] = `
         tabindex="-1"
       >
         3
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
     </ul>
     <div
@@ -700,11 +614,6 @@ exports[`options options as array of strings renders a closed combo box 1`] = `
         tabindex="-1"
       >
         Apple
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
       <li
         class="react-combo-boxes-combobox__option"
@@ -713,11 +622,6 @@ exports[`options options as array of strings renders a closed combo box 1`] = `
         tabindex="-1"
       >
         Banana
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
       <li
         class="react-combo-boxes-combobox__option"
@@ -726,11 +630,6 @@ exports[`options options as array of strings renders a closed combo box 1`] = `
         tabindex="-1"
       >
         Orange
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
     </ul>
     <div
@@ -804,13 +703,7 @@ exports[`options options as null renders an option with an empty string 1`] = `
         id="id_option_"
         role="option"
         tabindex="-1"
-      >
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
-      </li>
+      />
       <li
         class="react-combo-boxes-combobox__option"
         id="id_option_foo"
@@ -818,11 +711,6 @@ exports[`options options as null renders an option with an empty string 1`] = `
         tabindex="-1"
       >
         foo
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
     </ul>
     <div
@@ -897,13 +785,7 @@ exports[`options options as undefined renders an option with an empty string 1`]
         id="id_option_"
         role="option"
         tabindex="-1"
-      >
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
-      </li>
+      />
       <li
         class="react-combo-boxes-combobox__option"
         id="id_option_foo"
@@ -911,11 +793,6 @@ exports[`options options as undefined renders an option with an empty string 1`]
         tabindex="-1"
       >
         foo
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-           
-        </span>
       </li>
     </ul>
     <div

--- a/src/components/__snapshots__/combo_box_table.test.jsx.snap
+++ b/src/components/__snapshots__/combo_box_table.test.jsx.snap
@@ -55,14 +55,14 @@ exports[`cells with class names renders a table with colgroups 1`] = `
             role="presentation"
           >
             <th
-              aria-hidden="true"
               class="react-combo-boxes-combobox__table-header foo"
+              id="id_column_label"
             >
               Foo
             </th>
             <th
-              aria-hidden="true"
               class="react-combo-boxes-combobox__table-header bar"
+              id="id_column_type"
             >
               Bar
             </th>
@@ -72,6 +72,7 @@ exports[`cells with class names renders a table with colgroups 1`] = `
           role="presentation"
         >
           <tr
+            aria-labelledby="id_column_label id_option_apple_cell_label id_column_type id_option_apple_cell_type"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_apple"
             role="option"
@@ -79,38 +80,21 @@ exports[`cells with class names renders a table with colgroups 1`] = `
           >
             <td
               class="react-combo-boxes-combobox__table-cell foo"
+              id="id_option_apple_cell_label"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Foo 
-              </span>
               Apple
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="react-combo-boxes-combobox__table-cell bar"
+              id="id_option_apple_cell_type"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Bar 
-              </span>
               Fruit
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
           <tr
+            aria-labelledby="id_column_label id_option_banana_cell_label id_column_type id_option_banana_cell_type"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_banana"
             role="option"
@@ -118,38 +102,21 @@ exports[`cells with class names renders a table with colgroups 1`] = `
           >
             <td
               class="react-combo-boxes-combobox__table-cell foo"
+              id="id_option_banana_cell_label"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Foo 
-              </span>
               Banana
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="react-combo-boxes-combobox__table-cell bar"
+              id="id_option_banana_cell_type"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Bar 
-              </span>
               Fruit
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
           <tr
+            aria-labelledby="id_column_label id_option_potato_cell_label id_column_type id_option_potato_cell_type"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_potato"
             role="option"
@@ -157,35 +124,17 @@ exports[`cells with class names renders a table with colgroups 1`] = `
           >
             <td
               class="react-combo-boxes-combobox__table-cell foo"
+              id="id_option_potato_cell_label"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Foo 
-              </span>
               Potato
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="react-combo-boxes-combobox__table-cell bar"
+              id="id_option_potato_cell_type"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Bar 
-              </span>
               Vegetable
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
         </tbody>
@@ -269,6 +218,7 @@ exports[`cells with html renders a table with colgroups 1`] = `
           role="presentation"
         >
           <tr
+            aria-labelledby="id_option_apple_cell_label id_option_apple_cell_type"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_apple"
             role="option"
@@ -276,28 +226,21 @@ exports[`cells with html renders a table with colgroups 1`] = `
           >
             <td
               class="foo"
+              id="id_option_apple_cell_label"
               role="presentation"
             >
               Apple
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="bar"
+              id="id_option_apple_cell_type"
               role="presentation"
             >
               Fruit
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
           <tr
+            aria-labelledby="id_option_banana_cell_label id_option_banana_cell_type"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_banana"
             role="option"
@@ -305,28 +248,21 @@ exports[`cells with html renders a table with colgroups 1`] = `
           >
             <td
               class="foo"
+              id="id_option_banana_cell_label"
               role="presentation"
             >
               Banana
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="bar"
+              id="id_option_banana_cell_type"
               role="presentation"
             >
               Fruit
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
           <tr
+            aria-labelledby="id_option_potato_cell_label id_option_potato_cell_type"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_potato"
             role="option"
@@ -334,25 +270,17 @@ exports[`cells with html renders a table with colgroups 1`] = `
           >
             <td
               class="foo"
+              id="id_option_potato_cell_label"
               role="presentation"
             >
               Potato
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="bar"
+              id="id_option_potato_cell_type"
               role="presentation"
             >
               Vegetable
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
         </tbody>
@@ -436,6 +364,7 @@ exports[`columns as names only renders a table as the list box 1`] = `
           role="presentation"
         >
           <tr
+            aria-labelledby="id_option_apple_cell_label id_option_apple_cell_type"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_apple"
             role="option"
@@ -443,28 +372,21 @@ exports[`columns as names only renders a table as the list box 1`] = `
           >
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_apple_cell_label"
               role="presentation"
             >
               Apple
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_apple_cell_type"
               role="presentation"
             >
               Fruit
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
           <tr
+            aria-labelledby="id_option_banana_cell_label id_option_banana_cell_type"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_banana"
             role="option"
@@ -472,28 +394,21 @@ exports[`columns as names only renders a table as the list box 1`] = `
           >
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_banana_cell_label"
               role="presentation"
             >
               Banana
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_banana_cell_type"
               role="presentation"
             >
               Fruit
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
           <tr
+            aria-labelledby="id_option_potato_cell_label id_option_potato_cell_type"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_potato"
             role="option"
@@ -501,29 +416,22 @@ exports[`columns as names only renders a table as the list box 1`] = `
           >
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_potato_cell_label"
               role="presentation"
             >
               Potato
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_potato_cell_type"
               role="presentation"
             >
               Vegetable
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
           <tr
             aria-disabled="true"
+            aria-labelledby="id_option_tomato_cell_label id_option_tomato_cell_type"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_tomato"
             role="option"
@@ -531,25 +439,17 @@ exports[`columns as names only renders a table as the list box 1`] = `
           >
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_tomato_cell_label"
               role="presentation"
             >
               Tomato
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_tomato_cell_type"
               role="presentation"
             >
               Vegetable
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
         </tbody>
@@ -636,14 +536,14 @@ exports[`columns with headers renders a table with headers 1`] = `
             role="presentation"
           >
             <th
-              aria-hidden="true"
               class="react-combo-boxes-combobox__table-header"
+              id="id_column_label"
             >
               Name
             </th>
             <th
-              aria-hidden="true"
               class="react-combo-boxes-combobox__table-header"
+              id="id_column_type"
             >
               Type
             </th>
@@ -653,6 +553,7 @@ exports[`columns with headers renders a table with headers 1`] = `
           role="presentation"
         >
           <tr
+            aria-labelledby="id_column_label id_option_apple_cell_label id_column_type id_option_apple_cell_type"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_apple"
             role="option"
@@ -660,38 +561,21 @@ exports[`columns with headers renders a table with headers 1`] = `
           >
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_apple_cell_label"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Name 
-              </span>
               Apple
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_apple_cell_type"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Type 
-              </span>
               Fruit
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
           <tr
+            aria-labelledby="id_column_label id_option_banana_cell_label id_column_type id_option_banana_cell_type"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_banana"
             role="option"
@@ -699,38 +583,21 @@ exports[`columns with headers renders a table with headers 1`] = `
           >
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_banana_cell_label"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Name 
-              </span>
               Banana
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_banana_cell_type"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Type 
-              </span>
               Fruit
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
           <tr
+            aria-labelledby="id_column_label id_option_potato_cell_label id_column_type id_option_potato_cell_type"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_potato"
             role="option"
@@ -738,35 +605,17 @@ exports[`columns with headers renders a table with headers 1`] = `
           >
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_potato_cell_label"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Name 
-              </span>
               Potato
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_potato_cell_type"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Type 
-              </span>
               Vegetable
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
         </tbody>
@@ -854,6 +703,7 @@ exports[`columns with html renders a table with colgroups 1`] = `
           role="presentation"
         >
           <tr
+            aria-labelledby="id_option_apple_cell_label id_option_apple_cell_type"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_apple"
             role="option"
@@ -861,28 +711,21 @@ exports[`columns with html renders a table with colgroups 1`] = `
           >
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_apple_cell_label"
               role="presentation"
             >
               Apple
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_apple_cell_type"
               role="presentation"
             >
               Fruit
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
           <tr
+            aria-labelledby="id_option_banana_cell_label id_option_banana_cell_type"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_banana"
             role="option"
@@ -890,28 +733,21 @@ exports[`columns with html renders a table with colgroups 1`] = `
           >
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_banana_cell_label"
               role="presentation"
             >
               Banana
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_banana_cell_type"
               role="presentation"
             >
               Fruit
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
           <tr
+            aria-labelledby="id_option_potato_cell_label id_option_potato_cell_type"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_potato"
             role="option"
@@ -919,25 +755,17 @@ exports[`columns with html renders a table with colgroups 1`] = `
           >
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_potato_cell_label"
               role="presentation"
             >
               Potato
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_potato_cell_type"
               role="presentation"
             >
               Vegetable
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
         </tbody>
@@ -1027,11 +855,13 @@ exports[`grouped renders a table with groups 1`] = `
               aria-hidden="true"
               class="react-combo-boxes-combobox__table-group-header"
               colspan="2"
+              id="id_group_fruit"
             >
               Fruit
             </th>
           </tr>
           <tr
+            aria-labelledby="id_group_fruit id_option_apple_cell_name id_option_apple_cell_colour"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_apple"
             role="option"
@@ -1039,33 +869,21 @@ exports[`grouped renders a table with groups 1`] = `
           >
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_apple_cell_name"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Fruit 
-              </span>
               Apple
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_apple_cell_colour"
               role="presentation"
             >
               Green
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
           <tr
+            aria-labelledby="id_group_fruit id_option_banana_cell_name id_option_banana_cell_colour"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_banana"
             role="option"
@@ -1073,30 +891,17 @@ exports[`grouped renders a table with groups 1`] = `
           >
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_banana_cell_name"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Fruit 
-              </span>
               Banana
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_banana_cell_colour"
               role="presentation"
             >
               Yellow
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
           <tr
@@ -1106,11 +911,13 @@ exports[`grouped renders a table with groups 1`] = `
               aria-hidden="true"
               class="react-combo-boxes-combobox__table-group-header"
               colspan="2"
+              id="id_group_vegetable"
             >
               Vegetable
             </th>
           </tr>
           <tr
+            aria-labelledby="id_group_vegetable id_option_potato_cell_name id_option_potato_cell_colour"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_potato"
             role="option"
@@ -1118,30 +925,17 @@ exports[`grouped renders a table with groups 1`] = `
           >
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_potato_cell_name"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Vegetable 
-              </span>
               Potato
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_potato_cell_colour"
               role="presentation"
             >
               Brown
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
         </tbody>
@@ -1228,14 +1022,14 @@ exports[`grouped with columns with headers renders a table with headers 1`] = `
             role="presentation"
           >
             <th
-              aria-hidden="true"
               class="react-combo-boxes-combobox__table-header"
+              id="id_column_label"
             >
               Name
             </th>
             <th
-              aria-hidden="true"
               class="react-combo-boxes-combobox__table-header"
+              id="id_column_colour"
             >
               Colour
             </th>
@@ -1251,11 +1045,13 @@ exports[`grouped with columns with headers renders a table with headers 1`] = `
               aria-hidden="true"
               class="react-combo-boxes-combobox__table-group-header"
               colspan="2"
+              id="id_group_fruit"
             >
               Fruit
             </th>
           </tr>
           <tr
+            aria-labelledby="id_group_fruit id_column_label id_option__cell_label id_column_colour id_option__cell_colour"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_"
             role="option"
@@ -1263,43 +1059,21 @@ exports[`grouped with columns with headers renders a table with headers 1`] = `
           >
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option__cell_label"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Fruit 
-              </span>
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Name 
-              </span>
               Apple
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option__cell_colour"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Colour 
-              </span>
               Green
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
           <tr
+            aria-labelledby="id_group_fruit id_column_label id_option_1_cell_label id_column_colour id_option_1_cell_colour"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_1"
             role="option"
@@ -1307,40 +1081,17 @@ exports[`grouped with columns with headers renders a table with headers 1`] = `
           >
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_1_cell_label"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Fruit 
-              </span>
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Name 
-              </span>
               Banana
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_1_cell_colour"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Colour 
-              </span>
               Yellow
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
           <tr
@@ -1350,11 +1101,13 @@ exports[`grouped with columns with headers renders a table with headers 1`] = `
               aria-hidden="true"
               class="react-combo-boxes-combobox__table-group-header"
               colspan="2"
+              id="id_group_vegetable"
             >
               Vegetable
             </th>
           </tr>
           <tr
+            aria-labelledby="id_group_vegetable id_column_label id_option_2_cell_label id_column_colour id_option_2_cell_colour"
             class="react-combo-boxes-combobox__table-row"
             id="id_option_2"
             role="option"
@@ -1362,40 +1115,17 @@ exports[`grouped with columns with headers renders a table with headers 1`] = `
           >
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_2_cell_label"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Vegetable 
-              </span>
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Name 
-              </span>
               Potato
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
             <td
               class="react-combo-boxes-combobox__table-cell"
+              id="id_option_2_cell_colour"
               role="presentation"
             >
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                Colour 
-              </span>
               Brown
-              <span
-                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-              >
-                 
-              </span>
             </td>
           </tr>
         </tbody>

--- a/src/components/__snapshots__/combo_box_table.test.jsx.snap
+++ b/src/components/__snapshots__/combo_box_table.test.jsx.snap
@@ -84,7 +84,7 @@ exports[`cells with class names renders a table with colgroups 1`] = `
               <span
                 class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
               >
-                Foo 
+                Foo 
               </span>
               Apple
               <span
@@ -100,7 +100,7 @@ exports[`cells with class names renders a table with colgroups 1`] = `
               <span
                 class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
               >
-                Bar 
+                Bar 
               </span>
               Fruit
               <span
@@ -123,7 +123,7 @@ exports[`cells with class names renders a table with colgroups 1`] = `
               <span
                 class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
               >
-                Foo 
+                Foo 
               </span>
               Banana
               <span
@@ -139,7 +139,7 @@ exports[`cells with class names renders a table with colgroups 1`] = `
               <span
                 class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
               >
-                Bar 
+                Bar 
               </span>
               Fruit
               <span
@@ -162,7 +162,7 @@ exports[`cells with class names renders a table with colgroups 1`] = `
               <span
                 class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
               >
-                Foo 
+                Foo 
               </span>
               Potato
               <span
@@ -178,7 +178,7 @@ exports[`cells with class names renders a table with colgroups 1`] = `
               <span
                 class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
               >
-                Bar 
+                Bar 
               </span>
               Vegetable
               <span
@@ -665,7 +665,7 @@ exports[`columns with headers renders a table with headers 1`] = `
               <span
                 class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
               >
-                Name 
+                Name 
               </span>
               Apple
               <span
@@ -681,7 +681,7 @@ exports[`columns with headers renders a table with headers 1`] = `
               <span
                 class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
               >
-                Type 
+                Type 
               </span>
               Fruit
               <span
@@ -704,7 +704,7 @@ exports[`columns with headers renders a table with headers 1`] = `
               <span
                 class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
               >
-                Name 
+                Name 
               </span>
               Banana
               <span
@@ -720,7 +720,7 @@ exports[`columns with headers renders a table with headers 1`] = `
               <span
                 class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
               >
-                Type 
+                Type 
               </span>
               Fruit
               <span
@@ -743,7 +743,7 @@ exports[`columns with headers renders a table with headers 1`] = `
               <span
                 class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
               >
-                Name 
+                Name 
               </span>
               Potato
               <span
@@ -759,7 +759,7 @@ exports[`columns with headers renders a table with headers 1`] = `
               <span
                 class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
               >
-                Type 
+                Type 
               </span>
               Vegetable
               <span
@@ -1044,7 +1044,7 @@ exports[`grouped renders a table with groups 1`] = `
               <span
                 class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
               >
-                Fruit 
+                Fruit 
               </span>
               Apple
               <span
@@ -1078,7 +1078,7 @@ exports[`grouped renders a table with groups 1`] = `
               <span
                 class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
               >
-                Fruit 
+                Fruit 
               </span>
               Banana
               <span
@@ -1123,7 +1123,7 @@ exports[`grouped renders a table with groups 1`] = `
               <span
                 class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
               >
-                Vegetable 
+                Vegetable 
               </span>
               Potato
               <span
@@ -1136,6 +1136,260 @@ exports[`grouped renders a table with groups 1`] = `
               class="react-combo-boxes-combobox__table-cell"
               role="presentation"
             >
+              Brown
+              <span
+                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+              >
+                 
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div
+      class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+      id="id_aria_description"
+    >
+      When results are available use up and down arrows to review and enter to select
+    </div>
+    <div
+      class="react-combo-boxes-combobox__not-found"
+      hidden=""
+      id="id_not_found"
+    />
+    <div
+      class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+    >
+      <div
+        aria-atomic="true"
+        aria-live="polite"
+        role="status"
+      >
+        <div />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`grouped with columns with headers renders a table with headers 1`] = `
+<div>
+  <div
+    aria-busy="false"
+    class="react-combo-boxes-combobox"
+  >
+    <input
+      aria-autocomplete="none"
+      aria-describedby="id_aria_description"
+      aria-expanded="false"
+      aria-labelledby="id-label"
+      aria-owns="id_listbox"
+      autocomplete="off"
+      class="react-combo-boxes-combobox__input"
+      id="id"
+      role="combobox"
+      type="text"
+      value=""
+    />
+    <span
+      class="react-combo-boxes-combobox__down-arrow"
+      id="id_down_arrow"
+    />
+    <span
+      aria-label="Clear"
+      aria-labelledby="id_clear_button id-label id"
+      class="react-combo-boxes-combobox__clear-button"
+      hidden=""
+      id="id_clear_button"
+      role="button"
+      tabindex="-1"
+    />
+    <div
+      class="react-combo-boxes-combobox__listbox react-combo-boxes-combobox__listbox--header"
+      hidden=""
+      tabindex="-1"
+    >
+      <table
+        aria-labelledby="id-label"
+        class="react-combo-boxes-combobox__table"
+        id="id_listbox"
+        role="listbox"
+        tabindex="-1"
+      >
+        <colgroup>
+          <col />
+          <col />
+        </colgroup>
+        <thead
+          role="presentation"
+        >
+          <tr
+            role="presentation"
+          >
+            <th
+              aria-hidden="true"
+              class="react-combo-boxes-combobox__table-header"
+            >
+              Name
+            </th>
+            <th
+              aria-hidden="true"
+              class="react-combo-boxes-combobox__table-header"
+            >
+              Colour
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          role="presentation"
+        >
+          <tr
+            class="react-combo-boxes-combobox__table-group-row"
+          >
+            <th
+              aria-hidden="true"
+              class="react-combo-boxes-combobox__table-group-header"
+              colspan="2"
+            >
+              Fruit
+            </th>
+          </tr>
+          <tr
+            class="react-combo-boxes-combobox__table-row"
+            id="id_option_"
+            role="option"
+            tabindex="-1"
+          >
+            <td
+              class="react-combo-boxes-combobox__table-cell"
+              role="presentation"
+            >
+              <span
+                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+              >
+                Fruit 
+              </span>
+              <span
+                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+              >
+                Name 
+              </span>
+              Apple
+              <span
+                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+              >
+                 
+              </span>
+            </td>
+            <td
+              class="react-combo-boxes-combobox__table-cell"
+              role="presentation"
+            >
+              <span
+                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+              >
+                Colour 
+              </span>
+              Green
+              <span
+                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+              >
+                 
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="react-combo-boxes-combobox__table-row"
+            id="id_option_1"
+            role="option"
+            tabindex="-1"
+          >
+            <td
+              class="react-combo-boxes-combobox__table-cell"
+              role="presentation"
+            >
+              <span
+                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+              >
+                Fruit 
+              </span>
+              <span
+                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+              >
+                Name 
+              </span>
+              Banana
+              <span
+                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+              >
+                 
+              </span>
+            </td>
+            <td
+              class="react-combo-boxes-combobox__table-cell"
+              role="presentation"
+            >
+              <span
+                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+              >
+                Colour 
+              </span>
+              Yellow
+              <span
+                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+              >
+                 
+              </span>
+            </td>
+          </tr>
+          <tr
+            class="react-combo-boxes-combobox__table-group-row"
+          >
+            <th
+              aria-hidden="true"
+              class="react-combo-boxes-combobox__table-group-header"
+              colspan="2"
+            >
+              Vegetable
+            </th>
+          </tr>
+          <tr
+            class="react-combo-boxes-combobox__table-row"
+            id="id_option_2"
+            role="option"
+            tabindex="-1"
+          >
+            <td
+              class="react-combo-boxes-combobox__table-cell"
+              role="presentation"
+            >
+              <span
+                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+              >
+                Vegetable 
+              </span>
+              <span
+                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+              >
+                Name 
+              </span>
+              Potato
+              <span
+                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+              >
+                 
+              </span>
+            </td>
+            <td
+              class="react-combo-boxes-combobox__table-cell"
+              role="presentation"
+            >
+              <span
+                class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+              >
+                Colour 
+              </span>
               Brown
               <span
                 class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"

--- a/src/components/__snapshots__/drop_down.test.jsx.snap
+++ b/src/components/__snapshots__/drop_down.test.jsx.snap
@@ -37,11 +37,6 @@ exports[`options as array of objects disabled sets the aria-disabled attribute 1
           tabindex="-1"
         >
           Apple
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
         <li
           aria-disabled="true"
@@ -51,11 +46,6 @@ exports[`options as array of objects disabled sets the aria-disabled attribute 1
           tabindex="-1"
         >
           Banana
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
       </ul>
     </div>
@@ -116,11 +106,6 @@ exports[`options as array of objects group renders grouped options 1`] = `
           tabindex="-1"
         >
           Apple
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
         <li
           aria-hidden="true"
@@ -137,14 +122,9 @@ exports[`options as array of objects group renders grouped options 1`] = `
           <span
             class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
           >
-            Citrus 
+            Citrus 
           </span>
           Orange
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
         <li
           class="react-combo-boxes-dropdown__option"
@@ -155,14 +135,9 @@ exports[`options as array of objects group renders grouped options 1`] = `
           <span
             class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
           >
-            Citrus 
+            Citrus 
           </span>
           Lemon
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
         <li
           aria-hidden="true"
@@ -179,14 +154,9 @@ exports[`options as array of objects group renders grouped options 1`] = `
           <span
             class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
           >
-            Berry 
+            Berry 
           </span>
           Raspberry
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
         <li
           class="react-combo-boxes-dropdown__option"
@@ -197,14 +167,9 @@ exports[`options as array of objects group renders grouped options 1`] = `
           <span
             class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
           >
-            Berry 
+            Berry 
           </span>
           Strawberry
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
       </ul>
     </div>
@@ -265,11 +230,6 @@ exports[`options as array of objects label renders a closed drop down 1`] = `
           tabindex="-1"
         >
           Apple
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
         <li
           class="react-combo-boxes-dropdown__option"
@@ -278,11 +238,6 @@ exports[`options as array of objects label renders a closed drop down 1`] = `
           tabindex="-1"
         >
           Banana
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
         <li
           class="react-combo-boxes-dropdown__option"
@@ -291,11 +246,6 @@ exports[`options as array of objects label renders a closed drop down 1`] = `
           tabindex="-1"
         >
           Orange
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
       </ul>
     </div>
@@ -354,13 +304,7 @@ exports[`options as array of objects missing label treats as a blank string 1`] 
           id="id_option_"
           role="option"
           tabindex="-1"
-        >
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
-        </li>
+        />
       </ul>
     </div>
     <div
@@ -420,11 +364,6 @@ exports[`options options as array of numbers renders a closed drop down 1`] = `
           tabindex="-1"
         >
           0
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
         <li
           class="react-combo-boxes-dropdown__option"
@@ -433,11 +372,6 @@ exports[`options options as array of numbers renders a closed drop down 1`] = `
           tabindex="-1"
         >
           1
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
         <li
           class="react-combo-boxes-dropdown__option"
@@ -446,11 +380,6 @@ exports[`options options as array of numbers renders a closed drop down 1`] = `
           tabindex="-1"
         >
           2
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
         <li
           class="react-combo-boxes-dropdown__option"
@@ -459,11 +388,6 @@ exports[`options options as array of numbers renders a closed drop down 1`] = `
           tabindex="-1"
         >
           3
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
       </ul>
     </div>
@@ -524,11 +448,6 @@ exports[`options options as array of strings renders a closed drop down 1`] = `
           tabindex="-1"
         >
           Apple
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
         <li
           class="react-combo-boxes-dropdown__option"
@@ -537,11 +456,6 @@ exports[`options options as array of strings renders a closed drop down 1`] = `
           tabindex="-1"
         >
           Banana
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
         <li
           class="react-combo-boxes-dropdown__option"
@@ -550,11 +464,6 @@ exports[`options options as array of strings renders a closed drop down 1`] = `
           tabindex="-1"
         >
           Orange
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
       </ul>
     </div>
@@ -613,13 +522,7 @@ exports[`options options as null renders a closed drop down with the option as a
           id="id_option_"
           role="option"
           tabindex="-1"
-        >
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
-        </li>
+        />
       </ul>
     </div>
     <div
@@ -677,13 +580,7 @@ exports[`options options as undefined renders a closed drop down with the option
           id="id_option_"
           role="option"
           tabindex="-1"
-        >
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
-        </li>
+        />
       </ul>
     </div>
     <div
@@ -744,11 +641,6 @@ exports[`options updating options updates the options 1`] = `
           tabindex="-1"
         >
           Strawberry
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
         <li
           class="react-combo-boxes-dropdown__option"
@@ -757,11 +649,6 @@ exports[`options updating options updates the options 1`] = `
           tabindex="-1"
         >
           Raspberry
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
         <li
           class="react-combo-boxes-dropdown__option"
@@ -770,11 +657,6 @@ exports[`options updating options updates the options 1`] = `
           tabindex="-1"
         >
           Banana
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
       </ul>
     </div>
@@ -835,11 +717,6 @@ exports[`placeholderOption renders a placeholder option 1`] = `
           tabindex="-1"
         >
           Please select…
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
         <li
           class="react-combo-boxes-dropdown__option"
@@ -848,11 +725,6 @@ exports[`placeholderOption renders a placeholder option 1`] = `
           tabindex="-1"
         >
           Apple
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
         <li
           class="react-combo-boxes-dropdown__option"
@@ -861,11 +733,6 @@ exports[`placeholderOption renders a placeholder option 1`] = `
           tabindex="-1"
         >
           Banana
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
         <li
           class="react-combo-boxes-dropdown__option"
@@ -874,11 +741,6 @@ exports[`placeholderOption renders a placeholder option 1`] = `
           tabindex="-1"
         >
           Orange
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-             
-          </span>
         </li>
       </ul>
     </div>

--- a/src/components/__snapshots__/drop_down.test.jsx.snap
+++ b/src/components/__snapshots__/drop_down.test.jsx.snap
@@ -110,65 +110,51 @@ exports[`options as array of objects group renders grouped options 1`] = `
         <li
           aria-hidden="true"
           class="react-combo-boxes-dropdown__group-label"
+          id="id_group_citrus"
         >
           Citrus
         </li>
         <li
+          aria-labelledby="id_group_citrus id_option_orange"
           class="react-combo-boxes-dropdown__option"
           id="id_option_orange"
           role="option"
           tabindex="-1"
         >
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-            Citrus 
-          </span>
           Orange
         </li>
         <li
+          aria-labelledby="id_group_citrus id_option_lemon"
           class="react-combo-boxes-dropdown__option"
           id="id_option_lemon"
           role="option"
           tabindex="-1"
         >
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-            Citrus 
-          </span>
           Lemon
         </li>
         <li
           aria-hidden="true"
           class="react-combo-boxes-dropdown__group-label"
+          id="id_group_berry"
         >
           Berry
         </li>
         <li
+          aria-labelledby="id_group_berry id_option_raspberry"
           class="react-combo-boxes-dropdown__option"
           id="id_option_raspberry"
           role="option"
           tabindex="-1"
         >
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-            Berry 
-          </span>
           Raspberry
         </li>
         <li
+          aria-labelledby="id_group_berry id_option_strawberry"
           class="react-combo-boxes-dropdown__option"
           id="id_option_strawberry"
           role="option"
           tabindex="-1"
         >
-          <span
-            class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-          >
-            Berry 
-          </span>
           Strawberry
         </li>
       </ul>

--- a/src/components/__snapshots__/drop_down_table.test.jsx.snap
+++ b/src/components/__snapshots__/drop_down_table.test.jsx.snap
@@ -40,6 +40,7 @@ exports[`cells with html renders a table with colgroups 1`] = `
             role="presentation"
           >
             <tr
+              aria-labelledby="id_option_apple_cell_label id_option_apple_cell_type"
               aria-selected="true"
               class="react-combo-boxes-dropdown__table-row"
               id="id_option_apple"
@@ -48,28 +49,21 @@ exports[`cells with html renders a table with colgroups 1`] = `
             >
               <td
                 class="foo"
+                id="id_option_apple_cell_label"
                 role="presentation"
               >
                 Apple
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
               <td
                 class="bar"
+                id="id_option_apple_cell_type"
                 role="presentation"
               >
                 Fruit
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
             </tr>
             <tr
+              aria-labelledby="id_option_banana_cell_label id_option_banana_cell_type"
               class="react-combo-boxes-dropdown__table-row"
               id="id_option_banana"
               role="option"
@@ -77,28 +71,21 @@ exports[`cells with html renders a table with colgroups 1`] = `
             >
               <td
                 class="foo"
+                id="id_option_banana_cell_label"
                 role="presentation"
               >
                 Banana
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
               <td
                 class="bar"
+                id="id_option_banana_cell_type"
                 role="presentation"
               >
                 Fruit
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
             </tr>
             <tr
+              aria-labelledby="id_option_potato_cell_label id_option_potato_cell_type"
               class="react-combo-boxes-dropdown__table-row"
               id="id_option_potato"
               role="option"
@@ -106,25 +93,17 @@ exports[`cells with html renders a table with colgroups 1`] = `
             >
               <td
                 class="foo"
+                id="id_option_potato_cell_label"
                 role="presentation"
               >
                 Potato
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
               <td
                 class="bar"
+                id="id_option_potato_cell_type"
                 role="presentation"
               >
                 Vegetable
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
             </tr>
           </tbody>
@@ -192,6 +171,7 @@ exports[`columns as names only renders a table as the list box 1`] = `
             role="presentation"
           >
             <tr
+              aria-labelledby="id_option_apple_cell_label id_option_apple_cell_type"
               aria-selected="true"
               class="react-combo-boxes-dropdown__table-row"
               id="id_option_apple"
@@ -200,28 +180,21 @@ exports[`columns as names only renders a table as the list box 1`] = `
             >
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_apple_cell_label"
                 role="presentation"
               >
                 Apple
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_apple_cell_type"
                 role="presentation"
               >
                 Fruit
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
             </tr>
             <tr
+              aria-labelledby="id_option_banana_cell_label id_option_banana_cell_type"
               class="react-combo-boxes-dropdown__table-row"
               id="id_option_banana"
               role="option"
@@ -229,28 +202,21 @@ exports[`columns as names only renders a table as the list box 1`] = `
             >
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_banana_cell_label"
                 role="presentation"
               >
                 Banana
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_banana_cell_type"
                 role="presentation"
               >
                 Fruit
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
             </tr>
             <tr
+              aria-labelledby="id_option_potato_cell_label id_option_potato_cell_type"
               class="react-combo-boxes-dropdown__table-row"
               id="id_option_potato"
               role="option"
@@ -258,29 +224,22 @@ exports[`columns as names only renders a table as the list box 1`] = `
             >
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_potato_cell_label"
                 role="presentation"
               >
                 Potato
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_potato_cell_type"
                 role="presentation"
               >
                 Vegetable
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
             </tr>
             <tr
               aria-disabled="true"
+              aria-labelledby="id_option_tomato_cell_label id_option_tomato_cell_type"
               class="react-combo-boxes-dropdown__table-row"
               id="id_option_tomato"
               role="option"
@@ -288,25 +247,17 @@ exports[`columns as names only renders a table as the list box 1`] = `
             >
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_tomato_cell_label"
                 role="presentation"
               >
                 Tomato
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_tomato_cell_type"
                 role="presentation"
               >
                 Vegetable
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
             </tr>
           </tbody>
@@ -377,14 +328,14 @@ exports[`columns with headers and grouped renders a table with headers 1`] = `
               role="presentation"
             >
               <th
-                aria-hidden="true"
                 class="react-combo-boxes-dropdown__table-header"
+                id="id_column_label"
               >
                 Name
               </th>
               <th
-                aria-hidden="true"
                 class="react-combo-boxes-dropdown__table-header"
+                id="id_column_colour"
               >
                 Colour
               </th>
@@ -400,11 +351,13 @@ exports[`columns with headers and grouped renders a table with headers 1`] = `
                 aria-hidden="true"
                 class="react-combo-boxes-dropdown__table-group-header"
                 colspan="2"
+                id="id_group_fruit"
               >
                 Fruit
               </th>
             </tr>
             <tr
+              aria-labelledby="id_group_fruit id_column_label id_option__cell_label id_column_colour id_option__cell_colour"
               aria-selected="true"
               class="react-combo-boxes-dropdown__table-row"
               id="id_option_"
@@ -413,43 +366,21 @@ exports[`columns with headers and grouped renders a table with headers 1`] = `
             >
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option__cell_label"
                 role="presentation"
               >
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                  Fruit 
-                </span>
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                  Name 
-                </span>
                 Apple
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option__cell_colour"
                 role="presentation"
               >
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                  Colour 
-                </span>
                 Green
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
             </tr>
             <tr
+              aria-labelledby="id_group_fruit id_column_label id_option_1_cell_label id_column_colour id_option_1_cell_colour"
               class="react-combo-boxes-dropdown__table-row"
               id="id_option_1"
               role="option"
@@ -457,40 +388,17 @@ exports[`columns with headers and grouped renders a table with headers 1`] = `
             >
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_1_cell_label"
                 role="presentation"
               >
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                  Fruit 
-                </span>
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                  Name 
-                </span>
                 Banana
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_1_cell_colour"
                 role="presentation"
               >
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                  Colour 
-                </span>
                 Yellow
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
             </tr>
             <tr
@@ -500,11 +408,13 @@ exports[`columns with headers and grouped renders a table with headers 1`] = `
                 aria-hidden="true"
                 class="react-combo-boxes-dropdown__table-group-header"
                 colspan="2"
+                id="id_group_vegetable"
               >
                 Vegetable
               </th>
             </tr>
             <tr
+              aria-labelledby="id_group_vegetable id_column_label id_option_2_cell_label id_column_colour id_option_2_cell_colour"
               class="react-combo-boxes-dropdown__table-row"
               id="id_option_2"
               role="option"
@@ -512,40 +422,17 @@ exports[`columns with headers and grouped renders a table with headers 1`] = `
             >
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_2_cell_label"
                 role="presentation"
               >
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                  Vegetable 
-                </span>
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                  Name 
-                </span>
                 Potato
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_2_cell_colour"
                 role="presentation"
               >
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                  Colour 
-                </span>
                 Brown
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
             </tr>
           </tbody>
@@ -616,14 +503,14 @@ exports[`columns with headers renders a table with headers 1`] = `
               role="presentation"
             >
               <th
-                aria-hidden="true"
                 class="react-combo-boxes-dropdown__table-header"
+                id="id_column_label"
               >
                 Name
               </th>
               <th
-                aria-hidden="true"
                 class="react-combo-boxes-dropdown__table-header"
+                id="id_column_type"
               >
                 Type
               </th>
@@ -633,6 +520,7 @@ exports[`columns with headers renders a table with headers 1`] = `
             role="presentation"
           >
             <tr
+              aria-labelledby="id_column_label id_option_apple_cell_label id_column_type id_option_apple_cell_type"
               aria-selected="true"
               class="react-combo-boxes-dropdown__table-row"
               id="id_option_apple"
@@ -641,38 +529,21 @@ exports[`columns with headers renders a table with headers 1`] = `
             >
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_apple_cell_label"
                 role="presentation"
               >
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                  Name 
-                </span>
                 Apple
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_apple_cell_type"
                 role="presentation"
               >
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                  Type 
-                </span>
                 Fruit
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
             </tr>
             <tr
+              aria-labelledby="id_column_label id_option_banana_cell_label id_column_type id_option_banana_cell_type"
               class="react-combo-boxes-dropdown__table-row"
               id="id_option_banana"
               role="option"
@@ -680,38 +551,21 @@ exports[`columns with headers renders a table with headers 1`] = `
             >
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_banana_cell_label"
                 role="presentation"
               >
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                  Name 
-                </span>
                 Banana
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_banana_cell_type"
                 role="presentation"
               >
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                  Type 
-                </span>
                 Fruit
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
             </tr>
             <tr
+              aria-labelledby="id_column_label id_option_potato_cell_label id_column_type id_option_potato_cell_type"
               class="react-combo-boxes-dropdown__table-row"
               id="id_option_potato"
               role="option"
@@ -719,35 +573,17 @@ exports[`columns with headers renders a table with headers 1`] = `
             >
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_potato_cell_label"
                 role="presentation"
               >
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                  Name 
-                </span>
                 Potato
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_potato_cell_type"
                 role="presentation"
               >
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                  Type 
-                </span>
                 Vegetable
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
             </tr>
           </tbody>
@@ -819,6 +655,7 @@ exports[`columns with html renders a table with colgroups 1`] = `
             role="presentation"
           >
             <tr
+              aria-labelledby="id_option_apple_cell_label id_option_apple_cell_type"
               aria-selected="true"
               class="react-combo-boxes-dropdown__table-row"
               id="id_option_apple"
@@ -827,28 +664,21 @@ exports[`columns with html renders a table with colgroups 1`] = `
             >
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_apple_cell_label"
                 role="presentation"
               >
                 Apple
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_apple_cell_type"
                 role="presentation"
               >
                 Fruit
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
             </tr>
             <tr
+              aria-labelledby="id_option_banana_cell_label id_option_banana_cell_type"
               class="react-combo-boxes-dropdown__table-row"
               id="id_option_banana"
               role="option"
@@ -856,28 +686,21 @@ exports[`columns with html renders a table with colgroups 1`] = `
             >
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_banana_cell_label"
                 role="presentation"
               >
                 Banana
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_banana_cell_type"
                 role="presentation"
               >
                 Fruit
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
             </tr>
             <tr
+              aria-labelledby="id_option_potato_cell_label id_option_potato_cell_type"
               class="react-combo-boxes-dropdown__table-row"
               id="id_option_potato"
               role="option"
@@ -885,25 +708,17 @@ exports[`columns with html renders a table with colgroups 1`] = `
             >
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_potato_cell_label"
                 role="presentation"
               >
                 Potato
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_potato_cell_type"
                 role="presentation"
               >
                 Vegetable
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
             </tr>
           </tbody>
@@ -977,11 +792,13 @@ exports[`grouped renders a table with groups 1`] = `
                 aria-hidden="true"
                 class="react-combo-boxes-dropdown__table-group-header"
                 colspan="2"
+                id="id_group_fruit"
               >
                 Fruit
               </th>
             </tr>
             <tr
+              aria-labelledby="id_group_fruit id_option_apple_cell_name id_option_apple_cell_colour"
               aria-selected="true"
               class="react-combo-boxes-dropdown__table-row"
               id="id_option_apple"
@@ -990,33 +807,21 @@ exports[`grouped renders a table with groups 1`] = `
             >
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_apple_cell_name"
                 role="presentation"
               >
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                  Fruit 
-                </span>
                 Apple
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_apple_cell_colour"
                 role="presentation"
               >
                 Green
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
             </tr>
             <tr
+              aria-labelledby="id_group_fruit id_option_banana_cell_name id_option_banana_cell_colour"
               class="react-combo-boxes-dropdown__table-row"
               id="id_option_banana"
               role="option"
@@ -1024,30 +829,17 @@ exports[`grouped renders a table with groups 1`] = `
             >
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_banana_cell_name"
                 role="presentation"
               >
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                  Fruit 
-                </span>
                 Banana
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_banana_cell_colour"
                 role="presentation"
               >
                 Yellow
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
             </tr>
             <tr
@@ -1057,11 +849,13 @@ exports[`grouped renders a table with groups 1`] = `
                 aria-hidden="true"
                 class="react-combo-boxes-dropdown__table-group-header"
                 colspan="2"
+                id="id_group_vegetable"
               >
                 Vegetable
               </th>
             </tr>
             <tr
+              aria-labelledby="id_group_vegetable id_option_potato_cell_name id_option_potato_cell_colour"
               class="react-combo-boxes-dropdown__table-row"
               id="id_option_potato"
               role="option"
@@ -1069,30 +863,17 @@ exports[`grouped renders a table with groups 1`] = `
             >
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_potato_cell_name"
                 role="presentation"
               >
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                  Vegetable 
-                </span>
                 Potato
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
               <td
                 class="react-combo-boxes-dropdown__table-cell"
+                id="id_option_potato_cell_colour"
                 role="presentation"
               >
                 Brown
-                <span
-                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-                >
-                   
-                </span>
               </td>
             </tr>
           </tbody>

--- a/src/components/__snapshots__/drop_down_table.test.jsx.snap
+++ b/src/components/__snapshots__/drop_down_table.test.jsx.snap
@@ -334,6 +334,245 @@ exports[`columns as names only renders a table as the list box 1`] = `
 </div>
 `;
 
+exports[`columns with headers and grouped renders a table with headers 1`] = `
+<div>
+  <div
+    class="react-combo-boxes-dropdown"
+  >
+    <div
+      aria-describedby="id_aria_description"
+      aria-expanded="false"
+      aria-labelledby="id-label id"
+      aria-owns="id_listbox"
+      class="react-combo-boxes-dropdown__combobox"
+      id="id"
+      role="combobox"
+      tabindex="0"
+    >
+       
+    </div>
+    <div
+      class="react-combo-boxes-dropdown__listbox-wrapper"
+    >
+      <div
+        class="react-combo-boxes-dropdown__listbox react-combo-boxes-dropdown__listbox--header"
+        hidden=""
+        tabindex="-1"
+      >
+        <table
+          aria-labelledby="id-label"
+          class="react-combo-boxes-dropdown__table"
+          id="id_listbox"
+          role="listbox"
+          tabindex="-1"
+        >
+          <colgroup>
+            <col />
+            <col />
+          </colgroup>
+          <thead
+            role="presentation"
+          >
+            <tr
+              role="presentation"
+            >
+              <th
+                aria-hidden="true"
+                class="react-combo-boxes-dropdown__table-header"
+              >
+                Name
+              </th>
+              <th
+                aria-hidden="true"
+                class="react-combo-boxes-dropdown__table-header"
+              >
+                Colour
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            role="presentation"
+          >
+            <tr
+              class="react-combo-boxes-dropdown__table-group-row"
+            >
+              <th
+                aria-hidden="true"
+                class="react-combo-boxes-dropdown__table-group-header"
+                colspan="2"
+              >
+                Fruit
+              </th>
+            </tr>
+            <tr
+              aria-selected="true"
+              class="react-combo-boxes-dropdown__table-row"
+              id="id_option_"
+              role="option"
+              tabindex="-1"
+            >
+              <td
+                class="react-combo-boxes-dropdown__table-cell"
+                role="presentation"
+              >
+                <span
+                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+                >
+                  Fruit 
+                </span>
+                <span
+                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+                >
+                  Name 
+                </span>
+                Apple
+                <span
+                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+                >
+                   
+                </span>
+              </td>
+              <td
+                class="react-combo-boxes-dropdown__table-cell"
+                role="presentation"
+              >
+                <span
+                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+                >
+                  Colour 
+                </span>
+                Green
+                <span
+                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+                >
+                   
+                </span>
+              </td>
+            </tr>
+            <tr
+              class="react-combo-boxes-dropdown__table-row"
+              id="id_option_1"
+              role="option"
+              tabindex="-1"
+            >
+              <td
+                class="react-combo-boxes-dropdown__table-cell"
+                role="presentation"
+              >
+                <span
+                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+                >
+                  Fruit 
+                </span>
+                <span
+                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+                >
+                  Name 
+                </span>
+                Banana
+                <span
+                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+                >
+                   
+                </span>
+              </td>
+              <td
+                class="react-combo-boxes-dropdown__table-cell"
+                role="presentation"
+              >
+                <span
+                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+                >
+                  Colour 
+                </span>
+                Yellow
+                <span
+                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+                >
+                   
+                </span>
+              </td>
+            </tr>
+            <tr
+              class="react-combo-boxes-dropdown__table-group-row"
+            >
+              <th
+                aria-hidden="true"
+                class="react-combo-boxes-dropdown__table-group-header"
+                colspan="2"
+              >
+                Vegetable
+              </th>
+            </tr>
+            <tr
+              class="react-combo-boxes-dropdown__table-row"
+              id="id_option_2"
+              role="option"
+              tabindex="-1"
+            >
+              <td
+                class="react-combo-boxes-dropdown__table-cell"
+                role="presentation"
+              >
+                <span
+                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+                >
+                  Vegetable 
+                </span>
+                <span
+                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+                >
+                  Name 
+                </span>
+                Potato
+                <span
+                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+                >
+                   
+                </span>
+              </td>
+              <td
+                class="react-combo-boxes-dropdown__table-cell"
+                role="presentation"
+              >
+                <span
+                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+                >
+                  Colour 
+                </span>
+                Brown
+                <span
+                  class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+                >
+                   
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div
+      class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+      id="id_aria_description"
+    >
+      When results are available use up and down arrows to review and enter to select
+    </div>
+    <div
+      class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
+    >
+      <div
+        aria-atomic="true"
+        aria-live="polite"
+        role="status"
+      >
+        <div />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`columns with headers renders a table with headers 1`] = `
 <div>
   <div
@@ -407,7 +646,7 @@ exports[`columns with headers renders a table with headers 1`] = `
                 <span
                   class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
                 >
-                  Name 
+                  Name 
                 </span>
                 Apple
                 <span
@@ -423,7 +662,7 @@ exports[`columns with headers renders a table with headers 1`] = `
                 <span
                   class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
                 >
-                  Type 
+                  Type 
                 </span>
                 Fruit
                 <span
@@ -446,7 +685,7 @@ exports[`columns with headers renders a table with headers 1`] = `
                 <span
                   class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
                 >
-                  Name 
+                  Name 
                 </span>
                 Banana
                 <span
@@ -462,7 +701,7 @@ exports[`columns with headers renders a table with headers 1`] = `
                 <span
                   class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
                 >
-                  Type 
+                  Type 
                 </span>
                 Fruit
                 <span
@@ -485,7 +724,7 @@ exports[`columns with headers renders a table with headers 1`] = `
                 <span
                   class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
                 >
-                  Name 
+                  Name 
                 </span>
                 Potato
                 <span
@@ -501,7 +740,7 @@ exports[`columns with headers renders a table with headers 1`] = `
                 <span
                   class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
                 >
-                  Type 
+                  Type 
                 </span>
                 Vegetable
                 <span
@@ -756,7 +995,7 @@ exports[`grouped renders a table with groups 1`] = `
                 <span
                   class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
                 >
-                  Fruit 
+                  Fruit 
                 </span>
                 Apple
                 <span
@@ -790,7 +1029,7 @@ exports[`grouped renders a table with groups 1`] = `
                 <span
                   class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
                 >
-                  Fruit 
+                  Fruit 
                 </span>
                 Banana
                 <span
@@ -835,7 +1074,7 @@ exports[`grouped renders a table with groups 1`] = `
                 <span
                   class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
                 >
-                  Vegetable 
+                  Vegetable 
                 </span>
                 Potato
                 <span

--- a/src/components/aria_live_message.jsx
+++ b/src/components/aria_live_message.jsx
@@ -23,9 +23,12 @@ export function AriaLiveMessage({
     if (showNotFound) {
       newMessage = notFoundMessage?.();
     } else if (showListBox) {
-      newMessage = foundOptionsMessage?.(options);
+      newMessage = foundOptionsMessage?.(options) || '';
       if (focusedOption) {
-        newMessage += `, ${selectedOptionMessage?.(focusedOption, options)}`;
+        if (newMessage) {
+          newMessage += ', ';
+        }
+        newMessage += selectedOptionMessage?.(focusedOption, options);
       }
     }
 

--- a/src/components/aria_live_message.test.jsx
+++ b/src/components/aria_live_message.test.jsx
@@ -105,6 +105,28 @@ it('generates a live found message for focused options', async () => {
   ]);
 });
 
+it('generates a live found message where found count if not returned', async () => {
+  jest.useFakeTimers();
+
+  const { getMessages } = liveMessages();
+  const { rerender } = render(<Test />);
+
+  rerender(
+    <Test
+      options={['Apple', 'Banana']}
+      showListBox
+      foundOptionsMessage={null}
+      focusedOption={{ index: 0, label: 'Apple' }}
+    />,
+  );
+
+  act(() => {
+    jest.advanceTimersByTime(1400);
+  });
+
+  expect(await getMessages()).toEqual(['Apple 1 of 2 is highlighted']);
+});
+
 it('debounces updating the message', async () => {
   jest.useFakeTimers();
 

--- a/src/components/combo_box.jsx
+++ b/src/components/combo_box.jsx
@@ -52,7 +52,6 @@ const defaultRenderGroup = ({ key, ...props }) => (
     {...props}
   />
 );
-const defaultRenderGroupAccessibleLabel = (props) => <span {...props} />;
 const defaultRenderGroupLabel = (props) => <li {...props} />;
 // eslint-disable-next-line react/jsx-no-useless-fragment
 const defaultRenderGroupName = (props) => <Fragment {...props} />;
@@ -140,7 +139,6 @@ export const ComboBox = memo(
         renderInput = defaultRenderInput,
         renderListBox = defaultRenderListBox,
         renderGroup = defaultRenderGroup,
-        renderGroupAccessibleLabel = defaultRenderGroupAccessibleLabel,
         renderGroupLabel = defaultRenderGroupLabel,
         renderGroupName = defaultRenderGroupName,
         renderOption = defaultRenderOption,
@@ -207,7 +205,6 @@ export const ComboBox = memo(
         renderClearButton,
         renderDownArrow,
         renderGroup,
-        renderGroupAccessibleLabel,
         renderGroupLabel,
         renderGroupName,
         renderInput,
@@ -656,7 +653,6 @@ ComboBox.propTypes = {
   renderInput: PropTypes.func,
   renderListBox: PropTypes.func,
   renderGroup: PropTypes.func,
-  renderGroupAccessibleLabel: PropTypes.func,
   renderGroupLabel: PropTypes.func,
   renderGroupName: PropTypes.func,
   renderOption: PropTypes.func,

--- a/src/components/combo_box.test.jsx
+++ b/src/components/combo_box.test.jsx
@@ -1164,7 +1164,7 @@ describe('options', () => {
         await userEvent.tab();
         await userEvent.keyboard('{ArrowDown}{ArrowDown}');
         expectToHaveFocusedOption(
-          screen.getByRole('option', { name: /Orange/ }),
+          screen.getByRole('option', { name: 'Citrus Orange' }),
         );
       });
 
@@ -1178,6 +1178,21 @@ describe('options', () => {
         );
         await userEvent.tab();
         await userEvent.keyboard('{ArrowDown}{ArrowDown}{Enter}');
+        expect(spy).toHaveBeenCalledWith({ label: 'Orange', group: 'Citrus' });
+      });
+
+      it('triggers onValue when an option is selected by clicking', async () => {
+        const spy = jest.fn();
+        render(
+          <ComboBoxWrapper
+            options={options}
+            onValue={spy}
+          />,
+        );
+        await userEvent.tab();
+        await userEvent.click(
+          screen.getByRole('option', { name: 'Citrus Orange' }),
+        );
         expect(spy).toHaveBeenCalledWith({ label: 'Orange', group: 'Citrus' });
       });
 
@@ -2143,9 +2158,9 @@ describe('onSearch', () => {
       rerender(<ComboBoxWrapper options={newOptions} />);
       expect(container).toMatchSnapshot();
       expect(screen.getAllByRole('option').map((o) => o.textContent)).toEqual([
-        'Strawberry\u00A0',
-        'Raspberry\u00A0',
-        'Banana\u00A0',
+        'Strawberry',
+        'Raspberry',
+        'Banana',
       ]);
     });
 
@@ -4561,7 +4576,7 @@ describe('renderGroupAccessibleLabel', () => {
     await userEvent.tab();
     expect(spy).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        children: 'bar\u00A0',
+        children: 'bar ',
       }),
       {
         'aria-autocomplete': 'none',

--- a/src/components/combo_box.test.jsx
+++ b/src/components/combo_box.test.jsx
@@ -4543,56 +4543,6 @@ describe('renderOption', () => {
   });
 });
 
-describe('renderGroupAccessibleLabel', () => {
-  it('allows the group accessible label to be replaced', async () => {
-    render(
-      <ComboBoxWrapper
-        options={[{ label: 'foo', group: 'bar' }]}
-        renderGroupAccessibleLabel={(props) => (
-          <dl
-            data-foo="bar"
-            {...props}
-          />
-        )}
-      />,
-    );
-    await userEvent.tab();
-    expect(screen.getByRole('option').firstChild.tagName).toEqual('DL');
-    expect(screen.getByRole('option').firstChild).toHaveAttribute(
-      'data-foo',
-      'bar',
-    );
-  });
-
-  it('is called with context and props', async () => {
-    const spy = jest.fn(() => null);
-    render(
-      <ComboBoxWrapper
-        options={[{ label: 'foo', group: 'bar' }]}
-        renderGroupAccessibleLabel={spy}
-        test="foo"
-      />,
-    );
-    await userEvent.tab();
-    expect(spy).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        children: 'bar ',
-      }),
-      {
-        'aria-autocomplete': 'none',
-        'aria-busy': false,
-        expanded: true,
-        search: null,
-        notFound: false,
-        currentOption: null,
-        suggestedOption: null,
-        group: expect.objectContaining({ label: 'bar' }),
-      },
-      expect.objectContaining({ options: expect.any(Array), test: 'foo' }),
-    );
-  });
-});
-
 describe('renderValue', () => {
   it('allows the value to be replaced', async () => {
     render(
@@ -4816,19 +4766,6 @@ describe('renderNotFound', () => {
       },
       expect.objectContaining({ options: expect.any(Array), test: 'foo' }),
     );
-  });
-});
-
-describe('visuallyHiddenClassName', () => {
-  it('allows custom props', async () => {
-    render(
-      <ComboBoxWrapper
-        options={[{ label: 'foo', group: 'bar' }]}
-        visuallyHiddenClassName="bar"
-      />,
-    );
-    await userEvent.tab();
-    expect(screen.getByRole('option').firstChild).toHaveClass('bar');
   });
 });
 

--- a/src/components/combo_box_table.jsx
+++ b/src/components/combo_box_table.jsx
@@ -1,9 +1,10 @@
-import { Fragment, forwardRef, useMemo } from 'react';
+import { Fragment, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { ComboBox } from './combo_box';
 import { renderListBox } from './list_box_table/render_list_box';
 import { renderGroupLabel } from './list_box_table/render_group_label';
 import { renderOption } from './list_box_table/render_option';
+import { useNormalisedColumns } from '../hooks/use_normalised_columns';
 
 function renderNothing() {
   return null;
@@ -30,9 +31,6 @@ const defaultRenderTableRow = ({ key, ...props }) => (
     {...props}
   />
 );
-const defaultRenderTableCellColumnAccessibleLabel = (props) => (
-  <span {...props} />
-);
 const defaultRenderTableCell = ({ key, ...props }) => (
   <td
     key={key}
@@ -52,25 +50,13 @@ export const ComboBoxTable = forwardRef(
       renderTableGroupRow = defaultRenderTableGroupRow,
       renderTableGroupHeaderCell = defaultRenderTableGroupHeaderCell,
       renderTableRow = defaultRenderTableRow,
-      renderTableCellColumnAccessibleLabel = defaultRenderTableCellColumnAccessibleLabel,
       renderTableCell = defaultRenderTableCell,
       renderColumnValue = defaultRenderColumnValue,
       ...props
     },
     ref,
   ) => {
-    const columns = useMemo(
-      () =>
-        rawColumns.map((column) => {
-          if (typeof column === 'string') {
-            return {
-              name: column,
-            };
-          }
-          return column;
-        }),
-      [rawColumns],
-    );
+    const columns = useNormalisedColumns(rawColumns);
 
     return (
       <ComboBox
@@ -87,9 +73,6 @@ export const ComboBoxTable = forwardRef(
         renderTableGroupRow={renderTableGroupRow}
         renderTableGroupHeaderCell={renderTableGroupHeaderCell}
         renderTableRow={renderTableRow}
-        renderTableCellColumnAccessibleLabel={
-          renderTableCellColumnAccessibleLabel
-        }
         renderTableCell={renderTableCell}
         renderColumnValue={renderColumnValue}
       />
@@ -114,7 +97,6 @@ ComboBoxTable.propTypes = {
   renderTableGroupRow: PropTypes.func,
   renderTableGroupHeaderCell: PropTypes.func,
   renderTableRow: PropTypes.func,
-  renderTableCellColumnAccessibleLabel: PropTypes.func,
   renderTableCell: PropTypes.func,
   renderColumnValue: PropTypes.func,
 };

--- a/src/components/combo_box_table.test.jsx
+++ b/src/components/combo_box_table.test.jsx
@@ -515,7 +515,7 @@ describe('customisation', () => {
           currentOption: null,
           notFound: false,
           suggestedOption: null,
-          column: { label: 'Type', name: 'type' },
+          column: { label: 'Type', name: 'type', key: 'type' },
         },
         expect.objectContaining({
           options: expect.any(Array),
@@ -735,147 +735,13 @@ describe('customisation', () => {
           group: expect.objectContaining({ label: 'Vegetable' }),
           option: expect.objectContaining({ label: 'Potato' }),
           selected: false,
-          column: { label: 'Type', name: 'type' },
+          column: { label: 'Type', name: 'type', key: 'type' },
         },
         expect.objectContaining({
           options: expect.any(Array),
           test: 'foo',
           columns: expect.any(Array),
         }),
-      );
-    });
-  });
-
-  describe('renderGroupAccessibleLabel', () => {
-    it('allows a table cell accessible label to be replaced', async () => {
-      render(
-        <ComboBoxWrapper
-          options={options}
-          columns={columns}
-          mapOption={map}
-          renderGroupAccessibleLabel={(props) => (
-            <kbd
-              data-foo="bar"
-              {...props}
-            />
-          )}
-        />,
-      );
-      await userEvent.click(screen.getByRole('combobox'));
-      expect(
-        screen.getAllByRole('option')[0].querySelector('td > kbd'),
-      ).toHaveAttribute('data-foo', 'bar');
-    });
-
-    it('is called with context and props', () => {
-      const spy = jest.fn();
-      render(
-        <ComboBoxWrapper
-          options={options}
-          columns={columns}
-          mapOption={map}
-          renderGroupAccessibleLabel={spy}
-          test="foo"
-        />,
-      );
-      expect(spy).toHaveBeenLastCalledWith(
-        { children: 'Vegetable ', className: visuallyHiddenClassName },
-        {
-          'aria-autocomplete': 'none',
-          'aria-busy': false,
-          expanded: false,
-          search: null,
-          currentOption: null,
-          notFound: false,
-          suggestedOption: null,
-          group: expect.objectContaining({ label: 'Vegetable' }),
-          option: expect.objectContaining({ label: 'Potato' }),
-          selected: false,
-        },
-        expect.objectContaining({
-          options: expect.any(Array),
-          test: 'foo',
-          columns: expect.any(Array),
-        }),
-      );
-    });
-  });
-
-  describe('renderTableCellColumnAccessibleLabel', () => {
-    it('allows a table cell accessible label to be replaced', async () => {
-      render(
-        <ComboBoxWrapper
-          options={options}
-          columns={columns}
-          mapOption={map}
-          renderTableCellColumnAccessibleLabel={(props) => (
-            <kbd
-              data-foo="bar"
-              {...props}
-            />
-          )}
-        />,
-      );
-      await userEvent.click(screen.getByRole('combobox'));
-      expect(
-        screen.getAllByRole('option')[0].querySelector('td > kbd'),
-      ).toHaveAttribute('data-foo', 'bar');
-    });
-
-    it('is called with context and props', () => {
-      const spy = jest.fn();
-      render(
-        <ComboBoxWrapper
-          options={options}
-          columns={columns}
-          mapOption={map}
-          renderTableCellColumnAccessibleLabel={spy}
-          test="foo"
-        />,
-      );
-      expect(spy).toHaveBeenLastCalledWith(
-        { children: 'Type ', className: visuallyHiddenClassName },
-        {
-          'aria-autocomplete': 'none',
-          'aria-busy': false,
-          expanded: false,
-          search: null,
-          currentOption: null,
-          notFound: false,
-          suggestedOption: null,
-          group: expect.objectContaining({ label: 'Vegetable' }),
-          option: expect.objectContaining({ label: 'Potato' }),
-          selected: false,
-          column: { label: 'Type', name: 'type' },
-        },
-        expect.objectContaining({
-          options: expect.any(Array),
-          test: 'foo',
-          columns: expect.any(Array),
-        }),
-      );
-    });
-
-    it('is has empty children if the column is empty', () => {
-      const testOptions = [{ name: 'Apple', type: 'Fruit', colour: '' }];
-      const spy = jest.fn();
-      render(
-        <ComboBoxWrapper
-          options={testOptions}
-          columns={columns}
-          mapOption={map}
-          renderTableCellColumnAccessibleLabel={spy}
-          test="foo"
-        />,
-      );
-      expect(spy).toHaveBeenCalledWith(
-        { children: null, className: visuallyHiddenClassName },
-        expect.objectContaining({
-          group: expect.objectContaining({ label: 'Fruit' }),
-          option: expect.objectContaining({ label: 'Apple' }),
-          column: { label: 'Colour', name: 'colour' },
-        }),
-        expect.anything(),
       );
     });
   });
@@ -925,7 +791,7 @@ describe('customisation', () => {
           group: expect.objectContaining({ label: 'Vegetable' }),
           option: expect.objectContaining({ label: 'Potato' }),
           selected: false,
-          column: { label: 'Type', name: 'type' },
+          column: { label: 'Type', name: 'type', key: 'type' },
         },
         expect.objectContaining({
           options: expect.any(Array),

--- a/src/components/combo_box_table.test.jsx
+++ b/src/components/combo_box_table.test.jsx
@@ -2,7 +2,6 @@ import { useState, forwardRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ComboBoxTable } from './combo_box_table';
-import { visuallyHiddenClassName } from '../constants/visually_hidden_class_name';
 
 const ComboBoxWrapper = forwardRef(({ value: initialValue, ...props }, ref) => {
   const [value, onValue] = useState(initialValue);

--- a/src/components/combo_box_table.test.jsx
+++ b/src/components/combo_box_table.test.jsx
@@ -48,7 +48,7 @@ describe('columns as names only', () => {
       />,
     );
     await userEvent.tab();
-    await userEvent.click(screen.getByRole('option', { name: /Banana/ }));
+    await userEvent.click(screen.getByRole('option', { name: 'Banana Fruit' }));
     expect(spy).toHaveBeenCalledWith({
       label: 'Banana',
       type: 'Fruit',
@@ -108,7 +108,9 @@ describe('columns with headers', () => {
       />,
     );
     await userEvent.tab();
-    await userEvent.click(screen.getByRole('option', { name: /Banana/ }));
+    await userEvent.click(
+      screen.getByRole('option', { name: 'Name Banana Type Fruit' }),
+    );
     expect(spy).toHaveBeenCalledWith({
       label: 'Banana',
       type: 'Fruit',
@@ -243,7 +245,9 @@ describe('grouped', () => {
       />,
     );
     await userEvent.tab();
-    await userEvent.click(screen.getByRole('option', { name: /Banana/ }));
+    await userEvent.click(
+      screen.getByRole('option', { name: 'Fruit Banana Yellow' }),
+    );
     expect(spy).toHaveBeenCalledWith({
       name: 'Banana',
       type: 'Fruit',
@@ -266,6 +270,78 @@ describe('grouped', () => {
 
     expect(spy).toHaveBeenCalledWith({
       name: 'Banana',
+      type: 'Fruit',
+      colour: 'Yellow',
+    });
+  });
+});
+
+describe('grouped with columns with headers', () => {
+  const options = [
+    { label: 'Apple', type: 'Fruit', colour: 'Green' },
+    { label: 'Banana', type: 'Fruit', colour: 'Yellow' },
+    { label: 'Potato', type: 'Vegetable', colour: 'Brown' },
+  ];
+
+  const columns = [
+    { name: 'label', label: 'Name' },
+    { name: 'colour', label: 'Colour' },
+  ];
+
+  function map({ name, type }) {
+    return {
+      label: name,
+      group: type,
+    };
+  }
+
+  it('renders a table with headers', () => {
+    const { container } = render(
+      <ComboBoxWrapper
+        options={options}
+        columns={columns}
+        mapOption={map}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('allows selection by click', async () => {
+    const spy = jest.fn();
+    render(
+      <ComboBoxWrapper
+        options={options}
+        columns={columns}
+        onValue={spy}
+        mapOption={map}
+      />,
+    );
+    await userEvent.tab();
+    await userEvent.click(
+      screen.getByRole('option', { name: 'Fruit Name Banana Colour Yellow' }),
+    );
+    expect(spy).toHaveBeenCalledWith({
+      label: 'Banana',
+      type: 'Fruit',
+      colour: 'Yellow',
+    });
+  });
+
+  it('allows selection by keyboard', async () => {
+    const spy = jest.fn();
+    render(
+      <ComboBoxWrapper
+        options={options}
+        columns={columns}
+        onValue={spy}
+        mapOption={map}
+      />,
+    );
+    await userEvent.tab();
+    await userEvent.keyboard('{ArrowDown}{ArrowDown}{Enter}');
+
+    expect(spy).toHaveBeenCalledWith({
+      label: 'Banana',
       type: 'Fruit',
       colour: 'Yellow',
     });
@@ -703,7 +779,7 @@ describe('customisation', () => {
         />,
       );
       expect(spy).toHaveBeenLastCalledWith(
-        { children: 'Vegetable\u00A0', className: visuallyHiddenClassName },
+        { children: 'Vegetable ', className: visuallyHiddenClassName },
         {
           'aria-autocomplete': 'none',
           'aria-busy': false,
@@ -758,7 +834,7 @@ describe('customisation', () => {
         />,
       );
       expect(spy).toHaveBeenLastCalledWith(
-        { children: 'Type\u00A0', className: visuallyHiddenClassName },
+        { children: 'Type ', className: visuallyHiddenClassName },
         {
           'aria-autocomplete': 'none',
           'aria-busy': false,

--- a/src/components/drop_down.test.jsx
+++ b/src/components/drop_down.test.jsx
@@ -1342,7 +1342,9 @@ describe('options', () => {
         render(<DropDownWrapper options={options} />);
         await userEvent.click(screen.getByRole('combobox'));
         await userEvent.keyboard('{ArrowDown}');
-        expect(document.activeElement).toHaveTextContent('Orange');
+        expectToHaveFocusedOption(
+          screen.getByRole('option', { name: 'Citrus Orange' }),
+        );
       });
 
       it('does not select a group by typing', async () => {
@@ -1362,6 +1364,21 @@ describe('options', () => {
         );
         await userEvent.click(screen.getByRole('combobox'));
         await userEvent.keyboard('{ArrowDown}{Enter}');
+        expect(spy).toHaveBeenCalledWith({ label: 'Orange', group: 'Citrus' });
+      });
+
+      it('triggers onValue when an option is selected by clicking', async () => {
+        const spy = jest.fn();
+        render(
+          <DropDownWrapper
+            options={options}
+            onValue={spy}
+          />,
+        );
+        await userEvent.click(screen.getByRole('combobox'));
+        await userEvent.click(
+          screen.getByRole('option', { name: 'Citrus Orange' }),
+        );
         expect(spy).toHaveBeenCalledWith({ label: 'Orange', group: 'Citrus' });
       });
 

--- a/src/components/drop_down_table.jsx
+++ b/src/components/drop_down_table.jsx
@@ -1,9 +1,10 @@
-import { Fragment, forwardRef, useMemo } from 'react';
+import { Fragment, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { DropDown } from './drop_down';
 import { renderListBox } from './list_box_table/render_list_box';
 import { renderGroupLabel } from './list_box_table/render_group_label';
 import { renderOption } from './list_box_table/render_option';
+import { useNormalisedColumns } from '../hooks/use_normalised_columns';
 
 function renderNothing() {
   return null;
@@ -59,18 +60,7 @@ export const DropDownTable = forwardRef(
     },
     ref,
   ) => {
-    const columns = useMemo(
-      () =>
-        rawColumns.map((column) => {
-          if (typeof column === 'string') {
-            return {
-              name: column,
-            };
-          }
-          return column;
-        }),
-      [rawColumns],
-    );
+    const columns = useNormalisedColumns(rawColumns);
 
     return (
       <DropDown

--- a/src/components/drop_down_table.test.jsx
+++ b/src/components/drop_down_table.test.jsx
@@ -47,7 +47,7 @@ describe('columns as names only', () => {
       />,
     );
     await userEvent.click(screen.getByRole('combobox'));
-    await userEvent.click(screen.getByRole('option', { name: /Banana/ }));
+    await userEvent.click(screen.getByRole('option', { name: 'Banana Fruit' }));
     expect(spy).toHaveBeenCalledWith({
       label: 'Banana',
       type: 'Fruit',
@@ -108,7 +108,9 @@ describe('columns with headers', () => {
       />,
     );
     await userEvent.click(screen.getByRole('combobox'));
-    await userEvent.click(screen.getByRole('option', { name: /Banana/ }));
+    await userEvent.click(
+      screen.getByRole('option', { name: 'Name Banana Type Fruit' }),
+    );
     expect(spy).toHaveBeenCalledWith({
       label: 'Banana',
       type: 'Fruit',
@@ -220,7 +222,9 @@ describe('grouped', () => {
       />,
     );
     await userEvent.click(screen.getByRole('combobox'));
-    await userEvent.click(screen.getByRole('option', { name: /Banana/ }));
+    await userEvent.click(
+      screen.getByRole('option', { name: 'Fruit Banana Yellow' }),
+    );
     expect(spy).toHaveBeenCalledWith({
       name: 'Banana',
       type: 'Fruit',
@@ -243,6 +247,78 @@ describe('grouped', () => {
 
     expect(spy).toHaveBeenCalledWith({
       name: 'Banana',
+      type: 'Fruit',
+      colour: 'Yellow',
+    });
+  });
+});
+
+describe('columns with headers and grouped', () => {
+  const options = [
+    { label: 'Apple', type: 'Fruit', colour: 'Green' },
+    { label: 'Banana', type: 'Fruit', colour: 'Yellow' },
+    { label: 'Potato', type: 'Vegetable', colour: 'Brown' },
+  ];
+
+  const columns = [
+    { name: 'label', label: 'Name' },
+    { name: 'colour', label: 'Colour' },
+  ];
+
+  function map({ name, type }) {
+    return {
+      label: name,
+      group: type,
+    };
+  }
+
+  it('renders a table with headers', () => {
+    const { container } = render(
+      <DropDownWrapper
+        options={options}
+        columns={columns}
+        mapOption={map}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('allows selection by click', async () => {
+    const spy = jest.fn();
+    render(
+      <DropDownWrapper
+        options={options}
+        columns={columns}
+        onValue={spy}
+        mapOption={map}
+      />,
+    );
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(
+      screen.getByRole('option', { name: 'Fruit Name Banana Colour Yellow' }),
+    );
+    expect(spy).toHaveBeenCalledWith({
+      label: 'Banana',
+      type: 'Fruit',
+      colour: 'Yellow',
+    });
+  });
+
+  it('allows selection by keyboard', async () => {
+    const spy = jest.fn();
+    render(
+      <DropDownWrapper
+        options={options}
+        columns={columns}
+        onValue={spy}
+        mapOption={map}
+      />,
+    );
+    await userEvent.tab();
+    await userEvent.keyboard('{ArrowDown}{ArrowDown}{Enter}');
+
+    expect(spy).toHaveBeenCalledWith({
+      label: 'Banana',
       type: 'Fruit',
       colour: 'Yellow',
     });

--- a/src/components/list_box.jsx
+++ b/src/components/list_box.jsx
@@ -87,13 +87,12 @@ export const ListBox = forwardRef(
                 onClick: disabled ? null : (e) => onSelectOption(e, option),
                 onFocus: onFocusOption ? (e) => onFocusOption(e, option) : null,
                 children: (
-                  // Use non-breaking spaces to fix an issue with Chrome on VoiceOver including spaces
                   <>
                     {group
                       ? renderGroupAccessibleLabel(
                           {
                             className: visuallyHiddenClassName,
-                            children: `${group.label}\u00A0`,
+                            children: `${group.label} `,
                           },
                           { ...componentState, group },
                           componentProps,
@@ -104,7 +103,6 @@ export const ListBox = forwardRef(
                       { ...componentState, selected, option, group },
                       componentProps,
                     )}
-                    <span className={visuallyHiddenClassName}>{'\u00A0'}</span>
                   </>
                 ),
               },

--- a/src/components/list_box.jsx
+++ b/src/components/list_box.jsx
@@ -16,12 +16,10 @@ export const ListBox = forwardRef(
         options,
         renderListBox,
         renderGroup,
-        renderGroupAccessibleLabel,
         renderGroupLabel,
         renderGroupName,
         renderOption,
         renderValue,
-        visuallyHiddenClassName,
         tabBetweenOptions,
       },
       componentState,
@@ -52,6 +50,7 @@ export const ListBox = forwardRef(
                       {
                         'aria-hidden': 'true',
                         className: makeBEMClass(classPrefix, 'group-label'),
+                        id: key,
                         ...html,
                         children: renderGroupName(
                           { children: label },
@@ -82,28 +81,15 @@ export const ListBox = forwardRef(
                 tabIndex: tabBetweenOptions && managedFocus ? 0 : -1,
                 'aria-selected': selected ? 'true' : null,
                 'aria-disabled': disabled ? 'true' : null,
+                'aria-labelledby': group ? `${group.key} ${key}` : null,
                 ref: selected ? focusedRef : null,
                 ...html,
                 onClick: disabled ? null : (e) => onSelectOption(e, option),
                 onFocus: onFocusOption ? (e) => onFocusOption(e, option) : null,
-                children: (
-                  <>
-                    {group
-                      ? renderGroupAccessibleLabel(
-                          {
-                            className: visuallyHiddenClassName,
-                            children: `${group.label} `,
-                          },
-                          { ...componentState, group },
-                          componentProps,
-                        )
-                      : null}
-                    {renderValue(
-                      { children: label },
-                      { ...componentState, selected, option, group },
-                      componentProps,
-                    )}
-                  </>
+                children: renderValue(
+                  { children: label },
+                  { ...componentState, selected, option, group },
+                  componentProps,
                 ),
               },
               { ...componentState, selected, option, group },
@@ -125,13 +111,11 @@ ListBox.propTypes = {
     options: PropTypes.array.isRequired,
     renderListBox: PropTypes.func.isRequired,
     renderGroup: PropTypes.func.isRequired,
-    renderGroupAccessibleLabel: PropTypes.func.isRequired,
     renderGroupLabel: PropTypes.func.isRequired,
     renderGroupName: PropTypes.func.isRequired,
     renderOption: PropTypes.func.isRequired,
     renderValue: PropTypes.func.isRequired,
     tabBetweenOptions: PropTypes.bool,
-    visuallyHiddenClassName: PropTypes.string.isRequired,
   }).isRequired,
   componentState: PropTypes.shape({
     currentOption: PropTypes.shape({

--- a/src/components/list_box_table/render_group_label.jsx
+++ b/src/components/list_box_table/render_group_label.jsx
@@ -8,6 +8,10 @@ export function renderGroupLabel(props, componentState, componentProps) {
     renderTableGroupHeaderCell,
   } = componentProps;
 
+  const {
+    group: { key },
+  } = componentState;
+
   return renderTableGroupRow(
     {
       className: makeBEMClass(classPrefix, 'table-group-row'),
@@ -16,6 +20,7 @@ export function renderGroupLabel(props, componentState, componentProps) {
           ...props,
           colSpan: Object.keys(columns).length,
           className: makeBEMClass(classPrefix, 'table-group-header'),
+          id: key,
         },
         componentState,
         componentProps,

--- a/src/components/list_box_table/render_list_box.jsx
+++ b/src/components/list_box_table/render_list_box.jsx
@@ -7,6 +7,7 @@ export function renderListBox(
   componentProps,
 ) {
   const {
+    id,
     classPrefix,
     columns,
     renderTableWrapper,
@@ -47,8 +48,8 @@ export function renderListBox(
                     {columns.map((column) =>
                       renderTableHeaderCell(
                         {
-                          'aria-hidden': 'true',
-                          key: column.name,
+                          key: column.key,
+                          id: `${id}_column_${column.key}`,
                           className: joinTokens(
                             makeBEMClass(classPrefix, 'table-header'),
                             column.cellClass,

--- a/src/components/list_box_table/render_option.jsx
+++ b/src/components/list_box_table/render_option.jsx
@@ -1,24 +1,35 @@
 import { makeBEMClass } from '../../helpers/make_bem_class';
 import { joinTokens } from '../../helpers/join_tokens';
 
-export function renderOption({ children: _, ...props }, state, componentProps) {
+export function renderOption(
+  { children: _, id, ...props },
+  state,
+  componentProps,
+) {
   const {
     classPrefix,
     columns,
     renderTableRow,
-    renderGroupAccessibleLabel,
-    renderTableCellColumnAccessibleLabel,
     renderTableCell,
     renderColumnValue,
-    visuallyHiddenClassName,
   } = componentProps;
   const { group, option } = state;
 
   return renderTableRow(
     {
       ...props,
+      id,
       className: makeBEMClass(classPrefix, 'table-row'),
-      children: columns.map((column, index) =>
+      'aria-labelledby': [
+        group?.key,
+        ...columns.flatMap((column) => [
+          column.label && `${componentProps.id}_column_${column.key}`,
+          `${option.key}_cell_${column.key}`,
+        ]),
+      ]
+        .filter(Boolean)
+        .join(' '),
+      children: columns.map((column) =>
         renderTableCell(
           {
             role: 'presentation',
@@ -26,40 +37,15 @@ export function renderOption({ children: _, ...props }, state, componentProps) {
               makeBEMClass(classPrefix, 'table-cell'),
               column.cellClass,
             ),
-            key: index,
+            key: column.key,
+            id: `${option.key}_cell_${column.key}`,
             ...column.cellHtml,
-            children: (
-              <>
-                {group &&
-                  index === 0 &&
-                  renderGroupAccessibleLabel(
-                    {
-                      className: visuallyHiddenClassName,
-                      children: `${group.label} `,
-                    },
-                    state,
-                    componentProps,
-                  )}
-                {column.label &&
-                  renderTableCellColumnAccessibleLabel(
-                    {
-                      className: visuallyHiddenClassName,
-                      children: option.value[column.name]
-                        ? `${column.label} `
-                        : null,
-                    },
-                    { ...state, column },
-                    componentProps,
-                  )}
-                {renderColumnValue(
-                  {
-                    children: option.value[column.name],
-                  },
-                  { ...state, column },
-                  componentProps,
-                )}
-                <span className={visuallyHiddenClassName}>{'\u00A0'}</span>
-              </>
+            children: renderColumnValue(
+              {
+                children: option.value[column.name],
+              },
+              { ...state, column },
+              componentProps,
             ),
           },
           { ...state, column },

--- a/src/components/list_box_table/render_option.jsx
+++ b/src/components/list_box_table/render_option.jsx
@@ -29,14 +29,13 @@ export function renderOption({ children: _, ...props }, state, componentProps) {
             key: index,
             ...column.cellHtml,
             children: (
-              // Use non-breaking spaces to fix an issue with Chrome on VoiceOver removing spaces
               <>
                 {group &&
                   index === 0 &&
                   renderGroupAccessibleLabel(
                     {
                       className: visuallyHiddenClassName,
-                      children: `${group.label}\u00A0`,
+                      children: `${group.label} `,
                     },
                     state,
                     componentProps,
@@ -46,7 +45,7 @@ export function renderOption({ children: _, ...props }, state, componentProps) {
                     {
                       className: visuallyHiddenClassName,
                       children: option.value[column.name]
-                        ? `${column.label}\u00A0`
+                        ? `${column.label} `
                         : null,
                     },
                     { ...state, column },

--- a/src/hooks/use_normalised_columns.js
+++ b/src/hooks/use_normalised_columns.js
@@ -1,0 +1,23 @@
+import { useMemo } from 'react';
+import { UniqueIdGenerator } from '../helpers/unique_id_generator';
+
+/**
+ * @private
+ */
+export function useNormalisedColumns(columns) {
+  return useMemo(() => {
+    const idGenerator = new UniqueIdGenerator();
+    return columns.map((column) => {
+      if (typeof column === 'string') {
+        return {
+          name: column,
+          key: idGenerator.uniqueId(column),
+        };
+      }
+      return {
+        ...column,
+        key: idGenerator.uniqueId(column.name),
+      };
+    });
+  }, [columns]);
+}


### PR DESCRIPTION
- Remove non-breaking space separators between options as the Mac Chrome bug requiring this has been resolved
- Removes the `renderGroupAccessibleLabel` and `renderTableCellColumnAccessibleLabel` from combo-boxes and drop downs as these are no longer required
- Use aria-labelledby for all option labels instead of inserting visually hidden text
- Fix an issue where drop down aria-live message was prefixed with "undefined"