### PR TITLE
use aria-labelledby on checkboxes and radios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## Unreleased
 
 - Remove non-breaking space separators between options as the Mac Chrome bug requiring this has been resolved
-- Removes the `renderGroupAccessibleLabel` and `renderTableCellColumnAccessibleLabel` from combo-boxes and drop downs as these are no longer required
-- Use aria-labelledby for all option labels instead of inserting visually hidden text
+- Use aria-labelledby for all option labels involving groups instead of inserting visually hidden text
+- Removes the `renderGroupAccessibleLabel` and `renderTableCellColumnAccessibleLabel` from all components as these are no longer required
 - Fix an issue where drop down aria-live message was prefixed with "undefined"
 - Switch to the ARIA 1.2 pattern as this now works better than the ARIA 1.0 pattern.
 - Removed `managedFocus` option. Focus for screen-readers now entirely uses `aria-activedescendant` which now works reliably over all screen-readers.

--- a/docs/checkboxes.md
+++ b/docs/checkboxes.md
@@ -87,15 +87,14 @@ Each render method has the signature
 
 The render functions available are:
 
-| Name                         | Default value                                         | Description                                                                        |
-| ---------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `renderWrapper`              | `({ key, ...props }) => <div key={key} {...props} />` | Renders the wrapper for each checkbox                                              |
-| `renderInput`                | `(props) => <input {...props} />`                     | Renders the checkbox input                                                         |
-| `renderLabel`                | `(props) => <label {...props} />`                     | Renders label for a checkbox                                                       |
-| `renderLabelWrapper`         | `(props) => <Fragment {...props} />`                  | Allows an element to wraps the label and description                               |
-| `renderDescription`          | `(props) => <div {...props} />`                       | Renders the optional description for checkbox                                      |
-| `renderGroup`                | `({ key, ...props }) => <div key={key} {...props} />` | Wraps a group of options                                                           |
-| `renderGroupLabel`           | `(props) => <div {...props} />`                       | Renders the visible label for a group. This will be ignored by a screen-reader     |
-| `renderGroupAccessibleLabel` | `(props) => <span {...props} />`                      | Renders the accessible label for a group. This will be read out before each option |
+| Name                 | Default value                                         | Description                                                                    |
+| -------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `renderWrapper`      | `({ key, ...props }) => <div key={key} {...props} />` | Renders the wrapper for each checkbox                                          |
+| `renderInput`        | `(props) => <input {...props} />`                     | Renders the checkbox input                                                     |
+| `renderLabel`        | `(props) => <label {...props} />`                     | Renders label for a checkbox                                                   |
+| `renderLabelWrapper` | `(props) => <Fragment {...props} />`                  | Allows an element to wraps the label and description                           |
+| `renderDescription`  | `(props) => <div {...props} />`                       | Renders the optional description for checkbox                                  |
+| `renderGroup`        | `({ key, ...props }) => <div key={key} {...props} />` | Wraps a group of options                                                       |
+| `renderGroupLabel`   | `(props) => <div {...props} />`                       | Renders the visible label for a group. This will be ignored by a screen-reader |
 
 [options]: options.md

--- a/docs/combo_box.md
+++ b/docs/combo_box.md
@@ -190,6 +190,10 @@ Sets the message to be read to a screen-reader when an option is highlighted.
 
 Defaults to: "label x of y is highlighted"
 
+#### `visuallyHiddenClassName: string = 'visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only'`
+
+The class name to visually hide an element. This is used for aria-live messages and highlighting.
+
 #### render props
 
 A number of render methods are provided to customise the appearance of the component.

--- a/docs/drop_down.md
+++ b/docs/drop_down.md
@@ -41,6 +41,10 @@ If you wish to submit the value add a `<input type="hidden" name="name" value="v
 
 This uses the same properties as [ComboBox][combo-box], with the following additions:
 
+#### `expandOnFocus: boolean = false`
+
+Expand the list box when then component is focused.
+
 ### `placeholderOption: string`
 
 Add a placeholder option as the first option in the list.

--- a/docs/radios.md
+++ b/docs/radios.md
@@ -90,15 +90,14 @@ Each render method has the signature
 
 The render functions available are:
 
-| Name                         | Default value                                         | Description                                                                        |
-| ---------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `renderWrapper`              | `({ key, ...props }) => <div key={key} {...props} />` | Renders the wrapper for each radio                                                 |
-| `renderInput`                | `(props) => <input {...props} />`                     | Renders the radio input                                                            |
-| `renderLabel`                | `(props) => <label {...props} />`                     | Renders label for a radio                                                          |
-| `renderLabelWrapper`         | `(props) => <Fragment {...props} />`                  | Allows an element to wraps the label and description                               |
-| `renderDescription`          | `(props) => <div {...props} />`                       | Renders the optional description for a radio                                       |
-| `renderGroup`                | `({ key, ...props }) => <div key={key} {...props} />` | Wraps a group of options                                                           |
-| `renderGroupLabel`           | `(props) => <div {...props} />`                       | Renders the visible label for a group. This will be ignored by a screen-reader     |
-| `renderGroupAccessibleLabel` | `(props) => <span {...props} />`                      | Renders the accessible label for a group. This will be read out before each option |
+| Name                 | Default value                                         | Description                                                                    |
+| -------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `renderWrapper`      | `({ key, ...props }) => <div key={key} {...props} />` | Renders the wrapper for each radio                                             |
+| `renderInput`        | `(props) => <input {...props} />`                     | Renders the radio input                                                        |
+| `renderLabel`        | `(props) => <label {...props} />`                     | Renders label for a radio                                                      |
+| `renderLabelWrapper` | `(props) => <Fragment {...props} />`                  | Allows an element to wraps the label and description                           |
+| `renderDescription`  | `(props) => <div {...props} />`                       | Renders the optional description for a radio                                   |
+| `renderGroup`        | `({ key, ...props }) => <div key={key} {...props} />` | Wraps a group of options                                                       |
+| `renderGroupLabel`   | `(props) => <div {...props} />`                       | Renders the visible label for a group. This will be ignored by a screen-reader |
 
 [options]: options.md

--- a/examples/drop_down/aria_1_2_groups/index.jsx
+++ b/examples/drop_down/aria_1_2_groups/index.jsx
@@ -32,6 +32,15 @@ function renderGroup(props, { groupChildren, group: { key, label } }) {
   );
 }
 
+function renderOption({ key, 'aria-labelledby': _, ...props }) {
+  return (
+    <li
+      key={key}
+      {...props}
+    />
+  );
+}
+
 export function Example() {
   const [value, setValue] = useState(null);
   const ref = useRef();
@@ -52,7 +61,7 @@ export function Example() {
         onValue={setValue}
         options={options}
         renderGroup={renderGroup}
-        renderGroupAccessibleLabel={() => null}
+        renderOption={renderOption}
       />
 
       <label htmlFor="output">Current value</label>

--- a/src/components/__snapshots__/checkboxes.test.jsx.snap
+++ b/src/components/__snapshots__/checkboxes.test.jsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`options as array of strings renders checkbox group 1`] = `
 <div>
@@ -14,6 +14,7 @@ exports[`options as array of strings renders checkbox group 1`] = `
     <label
       class="react-combo-boxes-checkbox__label"
       for="id_option_apple"
+      id="id_option_apple_label"
     >
       Apple
     </label>
@@ -30,6 +31,7 @@ exports[`options as array of strings renders checkbox group 1`] = `
     <label
       class="react-combo-boxes-checkbox__label"
       for="id_option_banana"
+      id="id_option_banana_label"
     >
       Banana
     </label>
@@ -46,6 +48,7 @@ exports[`options as array of strings renders checkbox group 1`] = `
     <label
       class="react-combo-boxes-checkbox__label"
       for="id_option_orange"
+      id="id_option_orange_label"
     >
       Orange
     </label>
@@ -67,6 +70,7 @@ exports[`options options as array of objects group renders grouped options 1`] =
     <label
       class="react-combo-boxes-checkbox__label"
       for="id_option_apple"
+      id="id_option_apple_label"
     >
       Apple
     </label>
@@ -76,6 +80,7 @@ exports[`options options as array of objects group renders grouped options 1`] =
   >
     <div
       class="react-combo-boxes-checkbox-group__label"
+      id="id_group_citrus"
     >
       Citrus
     </div>
@@ -83,6 +88,7 @@ exports[`options options as array of objects group renders grouped options 1`] =
       class="react-combo-boxes-checkbox"
     >
       <input
+        aria-labelledby="id_group_citrus id_option_orange_label"
         class="react-combo-boxes-checkbox__input"
         id="id_option_orange"
         type="checkbox"
@@ -91,12 +97,8 @@ exports[`options options as array of objects group renders grouped options 1`] =
       <label
         class="react-combo-boxes-checkbox__label"
         for="id_option_orange"
+        id="id_option_orange_label"
       >
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-          Citrus 
-        </span>
         Orange
       </label>
     </div>
@@ -104,6 +106,7 @@ exports[`options options as array of objects group renders grouped options 1`] =
       class="react-combo-boxes-checkbox"
     >
       <input
+        aria-labelledby="id_group_citrus id_option_lemon_label"
         class="react-combo-boxes-checkbox__input"
         id="id_option_lemon"
         type="checkbox"
@@ -112,12 +115,8 @@ exports[`options options as array of objects group renders grouped options 1`] =
       <label
         class="react-combo-boxes-checkbox__label"
         for="id_option_lemon"
+        id="id_option_lemon_label"
       >
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-          Citrus 
-        </span>
         Lemon
       </label>
     </div>
@@ -127,6 +126,7 @@ exports[`options options as array of objects group renders grouped options 1`] =
   >
     <div
       class="react-combo-boxes-checkbox-group__label"
+      id="id_group_berry"
     >
       Berry
     </div>
@@ -134,6 +134,7 @@ exports[`options options as array of objects group renders grouped options 1`] =
       class="react-combo-boxes-checkbox"
     >
       <input
+        aria-labelledby="id_group_berry id_option_raspberry_label"
         class="react-combo-boxes-checkbox__input"
         id="id_option_raspberry"
         type="checkbox"
@@ -142,12 +143,8 @@ exports[`options options as array of objects group renders grouped options 1`] =
       <label
         class="react-combo-boxes-checkbox__label"
         for="id_option_raspberry"
+        id="id_option_raspberry_label"
       >
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-          Berry 
-        </span>
         Raspberry
       </label>
     </div>
@@ -155,6 +152,7 @@ exports[`options options as array of objects group renders grouped options 1`] =
       class="react-combo-boxes-checkbox"
     >
       <input
+        aria-labelledby="id_group_berry id_option_strawberry_label"
         class="react-combo-boxes-checkbox__input"
         id="id_option_strawberry"
         type="checkbox"
@@ -163,12 +161,8 @@ exports[`options options as array of objects group renders grouped options 1`] =
       <label
         class="react-combo-boxes-checkbox__label"
         for="id_option_strawberry"
+        id="id_option_strawberry_label"
       >
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-          Berry 
-        </span>
         Strawberry
       </label>
     </div>

--- a/src/components/__snapshots__/radios.test.jsx.snap
+++ b/src/components/__snapshots__/radios.test.jsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`options as array of strings renders radio group 1`] = `
 <div>
@@ -15,6 +15,7 @@ exports[`options as array of strings renders radio group 1`] = `
     <label
       class="react-combo-boxes-radio__label"
       for="id_option_apple"
+      id="id_option_apple_label"
     >
       Apple
     </label>
@@ -32,6 +33,7 @@ exports[`options as array of strings renders radio group 1`] = `
     <label
       class="react-combo-boxes-radio__label"
       for="id_option_banana"
+      id="id_option_banana_label"
     >
       Banana
     </label>
@@ -49,6 +51,7 @@ exports[`options as array of strings renders radio group 1`] = `
     <label
       class="react-combo-boxes-radio__label"
       for="id_option_orange"
+      id="id_option_orange_label"
     >
       Orange
     </label>
@@ -71,6 +74,7 @@ exports[`options options as array of numbers renders radio group 1`] = `
     <label
       class="react-combo-boxes-radio__label"
       for="id_option_0"
+      id="id_option_0_label"
     >
       0
     </label>
@@ -88,6 +92,7 @@ exports[`options options as array of numbers renders radio group 1`] = `
     <label
       class="react-combo-boxes-radio__label"
       for="id_option_1"
+      id="id_option_1_label"
     >
       1
     </label>
@@ -105,6 +110,7 @@ exports[`options options as array of numbers renders radio group 1`] = `
     <label
       class="react-combo-boxes-radio__label"
       for="id_option_2"
+      id="id_option_2_label"
     >
       2
     </label>
@@ -122,6 +128,7 @@ exports[`options options as array of numbers renders radio group 1`] = `
     <label
       class="react-combo-boxes-radio__label"
       for="id_option_3"
+      id="id_option_3_label"
     >
       3
     </label>
@@ -144,6 +151,7 @@ exports[`options options as array of objects group renders grouped options 1`] =
     <label
       class="react-combo-boxes-radio__label"
       for="id_option_apple"
+      id="id_option_apple_label"
     >
       Apple
     </label>
@@ -153,6 +161,7 @@ exports[`options options as array of objects group renders grouped options 1`] =
   >
     <div
       class="react-combo-boxes-radio-group__label"
+      id="id_group_citrus"
     >
       Citrus
     </div>
@@ -160,6 +169,7 @@ exports[`options options as array of objects group renders grouped options 1`] =
       class="react-combo-boxes-radio"
     >
       <input
+        aria-labelledby="id_group_citrus id_option_orange_label"
         class="react-combo-boxes-radio__input"
         id="id_option_orange"
         name="name"
@@ -169,12 +179,8 @@ exports[`options options as array of objects group renders grouped options 1`] =
       <label
         class="react-combo-boxes-radio__label"
         for="id_option_orange"
+        id="id_option_orange_label"
       >
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-          Citrus 
-        </span>
         Orange
       </label>
     </div>
@@ -182,6 +188,7 @@ exports[`options options as array of objects group renders grouped options 1`] =
       class="react-combo-boxes-radio"
     >
       <input
+        aria-labelledby="id_group_citrus id_option_lemon_label"
         class="react-combo-boxes-radio__input"
         id="id_option_lemon"
         name="name"
@@ -191,12 +198,8 @@ exports[`options options as array of objects group renders grouped options 1`] =
       <label
         class="react-combo-boxes-radio__label"
         for="id_option_lemon"
+        id="id_option_lemon_label"
       >
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-          Citrus 
-        </span>
         Lemon
       </label>
     </div>
@@ -206,6 +209,7 @@ exports[`options options as array of objects group renders grouped options 1`] =
   >
     <div
       class="react-combo-boxes-radio-group__label"
+      id="id_group_berry"
     >
       Berry
     </div>
@@ -213,6 +217,7 @@ exports[`options options as array of objects group renders grouped options 1`] =
       class="react-combo-boxes-radio"
     >
       <input
+        aria-labelledby="id_group_berry id_option_raspberry_label"
         class="react-combo-boxes-radio__input"
         id="id_option_raspberry"
         name="name"
@@ -222,12 +227,8 @@ exports[`options options as array of objects group renders grouped options 1`] =
       <label
         class="react-combo-boxes-radio__label"
         for="id_option_raspberry"
+        id="id_option_raspberry_label"
       >
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-          Berry 
-        </span>
         Raspberry
       </label>
     </div>
@@ -235,6 +236,7 @@ exports[`options options as array of objects group renders grouped options 1`] =
       class="react-combo-boxes-radio"
     >
       <input
+        aria-labelledby="id_group_berry id_option_strawberry_label"
         class="react-combo-boxes-radio__input"
         id="id_option_strawberry"
         name="name"
@@ -244,12 +246,8 @@ exports[`options options as array of objects group renders grouped options 1`] =
       <label
         class="react-combo-boxes-radio__label"
         for="id_option_strawberry"
+        id="id_option_strawberry_label"
       >
-        <span
-          class="visually-hidden visuallyhidden sr-only react-combo-boxes-sr-only"
-        >
-          Berry 
-        </span>
         Strawberry
       </label>
     </div>
@@ -272,6 +270,7 @@ exports[`options options as array of objects label renders radio group 1`] = `
     <label
       class="react-combo-boxes-radio__label"
       for="id_option_apple"
+      id="id_option_apple_label"
     >
       Apple
     </label>
@@ -289,6 +288,7 @@ exports[`options options as array of objects label renders radio group 1`] = `
     <label
       class="react-combo-boxes-radio__label"
       for="id_option_banana"
+      id="id_option_banana_label"
     >
       Banana
     </label>
@@ -306,6 +306,7 @@ exports[`options options as array of objects label renders radio group 1`] = `
     <label
       class="react-combo-boxes-radio__label"
       for="id_option_orange"
+      id="id_option_orange_label"
     >
       Orange
     </label>

--- a/src/components/checkboxes.jsx
+++ b/src/components/checkboxes.jsx
@@ -4,7 +4,6 @@ import { useNormalisedOptions } from '../hooks/use_normalised_options';
 import { renderGroupedOptions } from '../helpers/render_grouped_options';
 import { classPrefix as defaultClassPrefix } from '../constants/class_prefix';
 import { makeBEMClass } from '../helpers/make_bem_class';
-import { visuallyHiddenClassName } from '../constants/visually_hidden_class_name';
 
 const defaultRenderWrapper = ({ key, ...props }) => (
   <div
@@ -24,7 +23,6 @@ const defaultRenderGroup = ({ key, ...props }) => (
   />
 );
 const defaultRenderGroupLabel = (props) => <div {...props} />;
-const defaultRenderGroupAccessibleLabel = (props) => <span {...props} />;
 
 export const Checkboxes = memo(
   ({
@@ -41,7 +39,6 @@ export const Checkboxes = memo(
     renderDescription = defaultRenderDescription,
     renderGroup = defaultRenderGroup,
     renderGroupLabel = defaultRenderGroupLabel,
-    renderGroupAccessibleLabel = defaultRenderGroupAccessibleLabel,
     ...props
   }) => {
     const normalisedOptions = useNormalisedOptions({
@@ -63,7 +60,6 @@ export const Checkboxes = memo(
       renderDescription,
       renderGroup,
       renderGroupLabel,
-      renderGroupAccessibleLabel,
       ...props,
       normalisedOptions,
     });
@@ -121,6 +117,7 @@ export const Checkboxes = memo(
                   {
                     children: label,
                     className: makeBEMClass(groupClassPrefix, 'label'),
+                    id: key,
                     ...html,
                   },
                   { group },
@@ -140,6 +137,7 @@ export const Checkboxes = memo(
         const checked = selectedOptions.some(
           (item) => item.identity === identity,
         );
+        const labelledBy = group ? `${group.key} ${key}_label` : null;
 
         return renderWrapper(
           {
@@ -151,6 +149,7 @@ export const Checkboxes = memo(
                     'aria-describedby': description
                       ? `${key}_description`
                       : null,
+                    'aria-labelledby': labelledBy,
                     checked,
                     disabled,
                     id: key,
@@ -171,22 +170,9 @@ export const Checkboxes = memo(
                       {renderLabel(
                         {
                           htmlFor: key,
-                          children: (
-                            <>
-                              {group
-                                ? renderGroupAccessibleLabel(
-                                    {
-                                      className: visuallyHiddenClassName,
-                                      children: `${group.label} `,
-                                    },
-                                    { group },
-                                    optionisedProps,
-                                  )
-                                : null}
-                              {label}
-                            </>
-                          ),
+                          children: label,
                           className: makeBEMClass(classPrefix, 'label'),
+                          id: `${key}_label`,
                         },
                         { option, checked },
                         optionisedProps,
@@ -233,7 +219,6 @@ Checkboxes.propTypes = {
   renderDescription: PropTypes.func,
   renderGroup: PropTypes.func,
   renderGroupLabel: PropTypes.func,
-  renderGroupAccessibleLabel: PropTypes.func,
 };
 
 Checkboxes.displayName = 'Checkboxes';

--- a/src/components/checkboxes.test.jsx
+++ b/src/components/checkboxes.test.jsx
@@ -613,36 +613,3 @@ describe('renderGroupLabel', () => {
     );
   });
 });
-
-describe('renderGroupAccessibleLabel', () => {
-  it('customises the group accessible label', () => {
-    const spy = jest.fn((props) => (
-      <div
-        data-foo="bar"
-        {...props}
-      />
-    ));
-    render(
-      <Test
-        options={[{ label: 'Apple', group: 'fizz' }]}
-        renderGroupAccessibleLabel={spy}
-        test="foo"
-      />,
-    );
-
-    expect(document.querySelector('label').firstElementChild).toHaveAttribute(
-      'data-foo',
-      'bar',
-    );
-    expect(spy).toHaveBeenCalledWith(
-      expect.any(Object),
-      {
-        group: expect.objectContaining({ label: 'fizz' }),
-      },
-      expect.objectContaining({
-        options: expect.any(Array),
-        test: 'foo',
-      }),
-    );
-  });
-});

--- a/src/components/radios.jsx
+++ b/src/components/radios.jsx
@@ -4,7 +4,6 @@ import { useNormalisedOptions } from '../hooks/use_normalised_options';
 import { renderGroupedOptions } from '../helpers/render_grouped_options';
 import { classPrefix as defaultClassPrefix } from '../constants/class_prefix';
 import { makeBEMClass } from '../helpers/make_bem_class';
-import { visuallyHiddenClassName } from '../constants/visually_hidden_class_name';
 
 const defaultRenderWrapper = ({ key, ...props }) => (
   <div
@@ -24,7 +23,6 @@ const defaultRenderGroup = ({ key, ...props }) => (
   />
 );
 const defaultRenderGroupLabel = (props) => <div {...props} />;
-const defaultRenderGroupAccessibleLabel = (props) => <span {...props} />;
 
 export const Radios = memo(
   ({
@@ -40,7 +38,6 @@ export const Radios = memo(
     renderDescription = defaultRenderDescription,
     renderGroup = defaultRenderGroup,
     renderGroupLabel = defaultRenderGroupLabel,
-    renderGroupAccessibleLabel = defaultRenderGroupAccessibleLabel,
     required = false,
     value: _value = null,
     ...rawProps
@@ -57,7 +54,6 @@ export const Radios = memo(
       renderDescription,
       renderGroup,
       renderGroupLabel,
-      renderGroupAccessibleLabel,
       required,
       ...rawProps,
       ...useNormalisedOptions({
@@ -91,6 +87,7 @@ export const Radios = memo(
                   {
                     children: label,
                     className: makeBEMClass(groupClassPrefix, 'label'),
+                    id: key,
                     ...html,
                   },
                   { group },
@@ -108,6 +105,7 @@ export const Radios = memo(
         const { identity, label, key, html, disabled, description, group } =
           option;
         const checked = selectedOption?.identity === identity;
+        const labelledBy = group ? `${group.key} ${key}_label` : null;
 
         return renderWrapper(
           {
@@ -119,6 +117,7 @@ export const Radios = memo(
                     'aria-describedby': description
                       ? `${key}_description`
                       : null,
+                    'aria-labelledby': labelledBy,
                     checked,
                     disabled,
                     id: key,
@@ -139,22 +138,9 @@ export const Radios = memo(
                       {renderLabel(
                         {
                           htmlFor: key,
-                          children: (
-                            <>
-                              {group
-                                ? renderGroupAccessibleLabel(
-                                    {
-                                      className: visuallyHiddenClassName,
-                                      children: `${group.label} `,
-                                    },
-                                    { group },
-                                    optionisedProps,
-                                  )
-                                : null}
-                              {label}
-                            </>
-                          ),
+                          children: label,
                           className: makeBEMClass(classPrefix, 'label'),
+                          id: `${key}_label`,
                         },
                         { option, checked },
                         optionisedProps,
@@ -202,7 +188,6 @@ Radios.propTypes = {
   renderDescription: PropTypes.func,
   renderGroup: PropTypes.func,
   renderGroupLabel: PropTypes.func,
-  renderGroupAccessibleLabel: PropTypes.func,
 };
 
 Radios.displayName = 'Radios';

--- a/src/components/radios.test.jsx
+++ b/src/components/radios.test.jsx
@@ -636,36 +636,3 @@ describe('renderGroupLabel', () => {
     );
   });
 });
-
-describe('renderGroupAccessibleLabel', () => {
-  it('customises the group accessible label', () => {
-    const spy = jest.fn((props) => (
-      <div
-        data-foo="bar"
-        {...props}
-      />
-    ));
-    render(
-      <Test
-        options={[{ label: 'Apple', group: 'fizz' }]}
-        renderGroupAccessibleLabel={spy}
-        test="foo"
-      />,
-    );
-
-    expect(document.querySelector('label').firstElementChild).toHaveAttribute(
-      'data-foo',
-      'bar',
-    );
-    expect(spy).toHaveBeenCalledWith(
-      expect.any(Object),
-      {
-        group: expect.objectContaining({ label: 'fizz' }),
-      },
-      expect.objectContaining({
-        options: expect.any(Array),
-        test: 'foo',
-      }),
-    );
-  });
-});


### PR DESCRIPTION
Switch to using `aria-labelledby` for the labelling options with groups on the checkboxes and radios components.