### PR TITLE
Remove aria-activedescendant on the listbox

### DIFF
--- a/src/components/__snapshots__/drop_down.test.jsx.snap
+++ b/src/components/__snapshots__/drop_down.test.jsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`options as array of objects disabled sets the aria-disabled attribute 1`] = `
 <div>
@@ -22,7 +22,6 @@ exports[`options as array of objects disabled sets the aria-disabled attribute 1
       class="react-combo-boxes-dropdown__listbox-wrapper"
     >
       <ul
-        aria-activedescendant="id_option_apple"
         aria-labelledby="id-label"
         class="react-combo-boxes-dropdown__listbox"
         id="id_listbox"
@@ -592,7 +591,6 @@ exports[`options updating options updates the options 1`] = `
       class="react-combo-boxes-dropdown__listbox-wrapper"
     >
       <ul
-        aria-activedescendant="id_option_strawberry"
         aria-labelledby="id-label"
         class="react-combo-boxes-dropdown__listbox"
         id="id_listbox"

--- a/src/components/combo_box.jsx
+++ b/src/components/combo_box.jsx
@@ -503,10 +503,6 @@ export const ComboBox = memo(
                     id={`${id}_listbox`}
                     tabIndex={-1}
                     hidden={!showListBox}
-                    aria-activedescendant={
-                      (showListBox && focusListBox && focusedOption?.key) ||
-                      null
-                    }
                     aria-labelledby={joinTokens(ariaLabelledBy)}
                     onSelectOption={clickOption}
                     focusedRef={focusedRef}

--- a/src/components/combo_box.mac.test.jsx
+++ b/src/components/combo_box.mac.test.jsx
@@ -45,7 +45,7 @@ function expectToHaveActiveOption(option) {
   expect(listbox).toBeVisible();
   expect(combobox).toHaveAttribute('aria-expanded', 'true');
   expect(combobox).toHaveAttribute('aria-activedescendant', option.id);
-  expect(listbox).toHaveAttribute('aria-activedescendant', option.id);
+  expect(listbox).not.toHaveAttribute('aria-activedescendant');
   expect(option).toHaveAttribute('role', 'option');
   expect(option).toHaveAttribute('aria-selected', 'true');
   expect(combobox).toHaveFocus();

--- a/src/components/combo_box.test.jsx
+++ b/src/components/combo_box.test.jsx
@@ -79,7 +79,7 @@ function expectToHaveActiveOption(option, { focused = true } = {}) {
   expect(listbox).toBeVisible();
   expect(combobox).toHaveAttribute('aria-expanded', 'true');
   expect(combobox).toHaveAttribute('aria-activedescendant', option.id);
-  expect(listbox).toHaveAttribute('aria-activedescendant', option.id);
+  expect(listbox).not.toHaveAttribute('aria-activedescendant');
   expect(option).toHaveAttribute('role', 'option');
   expect(option).toHaveAttribute('aria-selected', 'true');
   if (focused) {

--- a/src/components/drop_down.test.jsx
+++ b/src/components/drop_down.test.jsx
@@ -23,6 +23,7 @@ const DropDownWrapper = forwardRef(({ value: _value, ...props }, ref) => {
 function expectToBeClosed() {
   const combobox = screen.getByRole('combobox');
   const listbox = screen.getByRole('listbox', { hidden: true });
+  expect(combobox).toHaveAttribute('aria-controls', listbox.id);
   expect(combobox).toHaveAttribute('role', 'combobox');
   expect(combobox).toHaveFocus();
   expect(listbox).not.toBeVisible();
@@ -34,12 +35,13 @@ function expectToBeClosed() {
 function expectToHaveActiveOption(option) {
   const combobox = screen.getByRole('combobox');
   const listbox = screen.getByRole('listbox', { hidden: true });
+  expect(combobox).toHaveAttribute('aria-controls', listbox.id);
   expect(combobox).toHaveFocus();
   expect(combobox).toHaveAttribute('role', 'combobox');
   expect(listbox).toBeVisible();
   expect(combobox).toHaveAttribute('aria-expanded', 'true');
   expect(combobox).toHaveAttribute('aria-activedescendant', option.id);
-  expect(listbox).toHaveAttribute('aria-activedescendant', option.id);
+  expect(listbox).not.toHaveAttribute('aria-activedescendant');
   expect(option).toHaveAttribute('role', 'option');
   expect(option).toHaveAttribute('aria-selected', 'true');
 }


### PR DESCRIPTION
Removes the `aria-activedescendant` from the listbox.

While not entirely incorrect, it was confusing Firefox on the mac and causing the focus to be moved to the listbox.  Also it is not present in the aria practices examples.